### PR TITLE
fix: pass repository to docker dispatch in release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -26,4 +26,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run docker.yaml --ref "$TAG_NAME"
+        run: gh workflow run docker.yaml --repo "$GITHUB_REPOSITORY" --ref "$TAG_NAME"


### PR DESCRIPTION
## Problem

The "Dispatch Docker build for the new release" step in `release-please.yaml` failed in production with:

```
failed to run git: fatal: not a git repository
```

The job has no `actions/checkout` step, so `gh workflow run docker.yaml --ref "$TAG_NAME"` tries to infer the target repository from the local git context, which doesn't exist.

## Fix

Add `--repo "$GITHUB_REPOSITORY"` to the `gh workflow run` call, consistent with how `weekly-release.yaml` already invokes `gh` commands.

Verified with `actionlint` and `python3 -c yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)