### PR TITLE
fix: use github app token for release automation

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,18 +12,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Dispatch Docker build for the new release
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-        run: gh workflow run docker.yaml --repo "$GITHUB_REPOSITORY" --ref "$TAG_NAME"
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -12,15 +12,21 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.RENOVATE_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
       - name: Find pending release-please PR
         id: find-pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --label "autorelease: pending" --state open --json number --jq '.[0].number // empty')
           if [ -z "$pr_number" ]; then
@@ -31,51 +37,21 @@ jobs:
           echo "Found pending release-please PR #$pr_number"
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
-      # The release PR is authored by github-actions[bot], so its own Test
-      # workflow runs require manual approval (action_required) and never
-      # complete - gh pr merge --auto and gh pr checks on the PR itself would
-      # wait/fail forever. The release PR only adds a version bump and
-      # changelog on top of main, and main is already exercised by Test on
-      # every push, so we instead verify the latest completed Test run on
-      # main succeeded and merge directly.
+      # The release PR is now authored using the GitHub App token, so it
+      # gets normal CI runs on it (no more action_required approval gating).
+      # Wait for its checks to finish and merge only if they are green.
       - name: Merge release PR
         id: merge-pr
         if: ${{ steps.find-pr.outputs.pr_number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           pr_number="${{ steps.find-pr.outputs.pr_number }}"
 
-          conclusion=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=test.yaml --branch main --status completed -L 1 --json conclusion --jq '.[0].conclusion // empty')
-
-          if [ "$conclusion" != "success" ]; then
-            echo "Latest completed Test run on main did not succeed (conclusion: '$conclusion'), aborting"
+          if ! gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" --watch --fail-fast; then
+            echo "Checks failed for PR #$pr_number, aborting"
             exit 1
           fi
 
-          echo "Latest Test run on main succeeded, merging PR #$pr_number"
+          echo "Checks succeeded, merging PR #$pr_number"
           gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --squash
-
-      - name: Wait for PR to be merged
-        id: wait-merge
-        if: ${{ steps.find-pr.outputs.pr_number != '' }}
-        run: |
-          pr_number="${{ steps.find-pr.outputs.pr_number }}"
-          merged="false"
-
-          for _ in $(seq 1 24); do
-            state=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')
-            if [ "$state" = "MERGED" ]; then
-              merged="true"
-              break
-            fi
-            sleep 5
-          done
-
-          if [ "$merged" != "true" ]; then
-            echo "PR #$pr_number was not merged within the timeout"
-            exit 1
-          fi
-          echo "PR #$pr_number merged"
-
-      - name: Dispatch release-please workflow
-        if: ${{ steps.find-pr.outputs.pr_number != '' }}
-        run: gh workflow run release-please.yaml --repo "$GITHUB_REPOSITORY" --ref main


### PR DESCRIPTION
## Summary

Switches the release pipeline from `GITHUB_TOKEN` + manual workflow dispatches to a GitHub App installation token, minted via `actions/create-github-app-token@v3.2.0` using the existing Renovate App credentials (`RENOVATE_CLIENT_ID` / `RENOVATE_PRIVATE_KEY`, Contents RW + Pull requests RW).

Events authored with an App installation token **do** trigger other workflows (unlike `GITHUB_TOKEN`), so the dispatch workarounds are no longer needed:

- `release-please.yaml`: the App token is passed to `googleapis/release-please-action` via `token:`. The "Dispatch Docker build for the new release" step is removed — the `release: published` event from the App-authored release now triggers `docker.yaml` directly. `actions: write` permission dropped (no longer dispatching).
- `weekly-release.yaml`: the App token is minted at the top of the job and used as `GH_TOKEN` for the `gh` calls. Since the release PR is now App-authored, its CI runs normally instead of sitting in `action_required`, so the merge gate goes back to checking the PR itself (`gh pr checks --watch --fail-fast`) rather than main's latest Test run. The "Wait for PR to be merged" and "Dispatch release-please workflow" steps are removed — the squash-merge push (made with the App token) now triggers `release-please.yaml` natively. `actions: write` permission dropped here too.
- `docker.yaml` left untouched.

Verified with `actionlint` and `python3 -c yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)