### PR TITLE
chore(ci): bump the pinned shared-workflows sha

### DIFF
--- a/.github/workflows/chart-guard.yaml
+++ b/.github/workflows/chart-guard.yaml
@@ -14,4 +14,4 @@ jobs:
     name: Guard chart version
     permissions:
       contents: read
-    uses: Soli0222/shared-workflows/.github/workflows/chart-guard.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/chart-guard.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -80,6 +80,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
     with:
       api-versions: monitoring.coreos.com/v1

--- a/.github/workflows/release-retry.yaml
+++ b/.github/workflows/release-retry.yaml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
     with:
       ref: ${{ needs.resolve.outputs.sha }}
       version: ${{ inputs.version }}
@@ -67,6 +67,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
     with:
       api-versions: monitoring.coreos.com/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
     with:
       ref: ${{ needs.release-please.outputs.sha }}
       version: ${{ needs.release-please.outputs.version }}
@@ -62,6 +62,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@30e0e231e39254bcc183366ec2a37f6ea0193bce
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
     with:
       api-versions: monitoring.coreos.com/v1


### PR DESCRIPTION
chart-guard が `Chart.yaml` のキー変更を**行 diff** で拾っていたため、release-please の `extra-files` による YAML ラウンドトリップを誤読していた。

emoji-renderer の release PR で実際に踏んだ:

```
-description: A Helm chart for the Emoji Renderer Service - Misskey Custom Emoji image generation microservice
+description: >-
+  A Helm chart for the Emoji Renderer Service - Misskey Custom Emoji image
+  generation microservice
```

値は同じなのに `description` が変わったと読み、経路 A ではなく**経路 C (構造変更 = minor 以上が必要)** と分類して落としていた。

Soli0222/shared-workflows@75c1e8b でパースした値どうしの比較に直したので、その sha を取り込む。整形差・キー順の入れ替え・引用符の違いをまとめて吸収する。

`helm package` も `Chart.yaml` を正規化するため、この整形差は梱包物には現れない。reconciler 側は元から影響を受けていないことを実際に package して確認済み。