### PR TITLE
feat(backend): filter out short interlude tracks from blends

### DIFF
--- a/.config/.env.example
+++ b/.config/.env.example
@@ -3,6 +3,8 @@ PORT=3000
 METRICS_PORT=9464
 APP_ORIGIN=http://127.0.0.1:3000
 ALLOWED_ORIGINS=http://127.0.0.1:3000
+# Exclude top tracks shorter than this duration when generating blends. Set to 0 to disable.
+MIN_TRACK_DURATION_MS=90000
 
 # Security
 # Use long random values in production.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ SPOTIFY_CLIENT_ID=あなたのClient ID
 SPOTIFY_CLIENT_SECRET=あなたのClient Secret
 ```
 
+ブレンド生成時には、既定で90秒未満のトップ曲を除外します。短尺の正規曲も残したい場合は、`MIN_TRACK_DURATION_MS` を調整してください。`0` に設定すると、この尺による除外を無効にできます。
+
 ### 3. アプリケーションを起動
 
 ```bash
@@ -143,6 +145,7 @@ docker-compose down -v
   - `reblend_playlist_created_total`: 作成されたプレイリスト総数
   - `reblend_blend_executed_total`: ブレンド実行回数
   - `reblend_active_users`: 現在の登録ユーザー数
+  - `reblend_tracks_filtered_total`: ブレンドから除外された曲数（`reason` は `duration` または `name`）
 
 #### Prometheus設定例 (`prometheus.yml`)
 

--- a/charts/spotify-reblend/Chart.yaml
+++ b/charts/spotify-reblend/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Spotify ReBlend application
 type: application
 sources:
   - https://github.com/Soli0222/spotify-reblend
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.5.0"

--- a/charts/spotify-reblend/templates/deployment.yaml
+++ b/charts/spotify-reblend/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: {{ .Values.otel.tracesSampler | quote }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ .Values.otel.tracesSamplerArg | quote }}
+            - name: MIN_TRACK_DURATION_MS
+              value: {{ .Values.config.minTrackDurationMs | quote }}
             - name: SPOTIFY_REDIRECT_URI
               value: {{ .Values.config.spotifyRedirectUri | quote }}
             - name: POSTGRES_USER

--- a/charts/spotify-reblend/values.yaml
+++ b/charts/spotify-reblend/values.yaml
@@ -40,6 +40,9 @@ config:
   appOrigin: "http://127.0.0.1:3000"
   allowedOrigins: "http://127.0.0.1:3000"
 
+  # Exclude top tracks shorter than this duration when generating blends. Set to 0 to disable.
+  minTrackDurationMs: 90000
+
   # Security secrets
   authSecret: ""
   tokenEncryptionKey: ""

--- a/packages/backend/src/services/playlist-generation.test.ts
+++ b/packages/backend/src/services/playlist-generation.test.ts
@@ -6,12 +6,14 @@ const mocks = vi.hoisted(() => ({
     query: vi.fn(),
     blendTracks: vi.fn(),
     getTopTracks: vi.fn(),
-    filterInstrumentalTracks: vi.fn(),
+    filterTracks: vi.fn(),
     createPlaylist: vi.fn(),
     addTracksToPlaylist: vi.fn(),
     clearPlaylistTracks: vi.fn(),
     followPlaylist: vi.fn(),
     refreshToken: vi.fn(),
+    tracksFiltered: vi.fn(),
+    loggerInfo: vi.fn(),
 }));
 
 vi.mock('../config/database', () => ({
@@ -25,7 +27,7 @@ vi.mock('./blend', () => ({
 vi.mock('./spotify', () => ({
     spotifyService: {
         getTopTracks: mocks.getTopTracks,
-        filterInstrumentalTracks: mocks.filterInstrumentalTracks,
+        filterTracks: mocks.filterTracks,
         createPlaylist: mocks.createPlaylist,
         addTracksToPlaylist: mocks.addTracksToPlaylist,
         clearPlaylistTracks: mocks.clearPlaylistTracks,
@@ -49,12 +51,13 @@ vi.mock('../utils/metrics', () => ({
     metrics: {
         playlistCreated: { inc: vi.fn() },
         blendExecuted: { inc: vi.fn() },
+        tracksFiltered: { inc: mocks.tracksFiltered },
     },
 }));
 
 vi.mock('../utils/logger', () => ({
     logger: {
-        info: vi.fn(),
+        info: mocks.loggerInfo,
         warn: vi.fn(),
         error: vi.fn(),
     },
@@ -92,7 +95,11 @@ function playlist(spotifyPlaylistId: string | null) {
 
 function setSuccessfulTrackCollection() {
     mocks.getTopTracks.mockResolvedValue([track]);
-    mocks.filterInstrumentalTracks.mockReturnValue([track]);
+    mocks.filterTracks.mockReturnValue({
+        tracks: [track],
+        filteredByDuration: 0,
+        filteredByName: 0,
+    });
     mocks.blendTracks.mockResolvedValue({ tracks: [track], contributionsByUser: new Map() });
 }
 
@@ -298,5 +305,34 @@ describe('generatePlaylist', () => {
             ok: false,
             reason: 'no-tracks',
         });
+    });
+
+    it('records track filters by reason', async () => {
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist(null)] })
+            .mockResolvedValueOnce({ rows: [member] })
+            .mockResolvedValueOnce({ rows: [{ spotify_id: 'owner-spotify-id', access_token: 'owner-access-token' }] })
+            .mockResolvedValue({ rows: [] });
+        mocks.filterTracks.mockReturnValue({
+            tracks: [track],
+            filteredByDuration: 2,
+            filteredByName: 3,
+        });
+        mocks.createPlaylist.mockResolvedValue({
+            id: 'new-spotify-playlist',
+            external_urls: { spotify: 'https://open.spotify.com/playlist/new-spotify-playlist' },
+        });
+
+        await generatePlaylist(12, { sortMode: 'shuffle' });
+
+        expect(mocks.tracksFiltered).toHaveBeenCalledWith({ reason: 'duration' }, 2);
+        expect(mocks.tracksFiltered).toHaveBeenCalledWith({ reason: 'name' }, 3);
+        expect(mocks.loggerInfo).toHaveBeenCalledWith({
+            playlistId: 12,
+            memberId: 1,
+            filteredByDuration: 2,
+            filteredByName: 3,
+            remaining: 1,
+        }, 'Filtered tracks for blend');
     });
 });

--- a/packages/backend/src/services/playlist-generation.ts
+++ b/packages/backend/src/services/playlist-generation.ts
@@ -4,6 +4,7 @@ import { spotifyService, SpotifyTrack } from './spotify';
 import { getValidAccessToken } from './spotify-token';
 import { decryptSecret } from '../utils/crypto';
 import { logger } from '../utils/logger';
+import { metrics } from '../utils/metrics';
 
 export type GenerateOutcome =
     | { ok: true; spotifyPlaylistId: string; spotifyUrl: string; trackCount: number; created: boolean; memberCount: number }
@@ -52,7 +53,22 @@ export async function generatePlaylist(
 
         try {
             let tracks = await spotifyService.getTopTracks(accessToken, 50);
-            tracks = spotifyService.filterInstrumentalTracks(tracks);
+            const filterResult = spotifyService.filterTracks(tracks);
+            tracks = filterResult.tracks;
+
+            if (filterResult.filteredByDuration > 0) {
+                metrics.tracksFiltered.inc({ reason: 'duration' }, filterResult.filteredByDuration);
+            }
+            if (filterResult.filteredByName > 0) {
+                metrics.tracksFiltered.inc({ reason: 'name' }, filterResult.filteredByName);
+            }
+            logger.info({
+                playlistId,
+                memberId: member.id,
+                filteredByDuration: filterResult.filteredByDuration,
+                filteredByName: filterResult.filteredByName,
+                remaining: tracks.length,
+            }, 'Filtered tracks for blend');
             userTracks.set(member.spotify_id, tracks);
         } catch (error) {
             logger.error({ err: error, memberId: member.id }, 'Failed to get top tracks');

--- a/packages/backend/src/services/spotify.test.ts
+++ b/packages/backend/src/services/spotify.test.ts
@@ -1,16 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { spotifyService } from './spotify';
 
 // Mock track for testing
-function createMockTrack(name: string) {
+function createMockTrack(name: string, duration_ms?: number) {
     return {
         id: `track-${name.replace(/\s/g, '-')}`,
         name,
         uri: `spotify:track:${name}`,
         artists: [{ name: 'Test Artist' }],
         album: { name: 'Test Album', images: [] },
+        ...(duration_ms === undefined ? {} : { duration_ms }),
     };
 }
+
+const originalMinTrackDurationMs = process.env.MIN_TRACK_DURATION_MS;
+
+afterEach(() => {
+    if (originalMinTrackDurationMs === undefined) {
+        delete process.env.MIN_TRACK_DURATION_MS;
+    } else {
+        process.env.MIN_TRACK_DURATION_MS = originalMinTrackDurationMs;
+    }
+});
 
 describe('filterInstrumentalTracks', () => {
     it('should filter tracks with "instrumental" in name', () => {
@@ -111,5 +122,79 @@ describe('filterInstrumentalTracks', () => {
 
         const result = spotifyService.filterInstrumentalTracks(tracks);
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('filterTracks', () => {
+    it('keeps tracks exactly at or above the minimum duration', () => {
+        const result = spotifyService.filterTracks([
+            createMockTrack('At threshold', 90000),
+            createMockTrack('Above threshold', 90001),
+        ], { minDurationMs: 90000 });
+
+        expect(result.tracks.map(track => track.name)).toEqual(['At threshold', 'Above threshold']);
+        expect(result.filteredByDuration).toBe(0);
+    });
+
+    it('filters tracks below the minimum duration', () => {
+        const result = spotifyService.filterTracks([
+            createMockTrack('Short interlude', 89999),
+            createMockTrack('Full song', 90001),
+        ], { minDurationMs: 90000 });
+
+        expect(result.tracks.map(track => track.name)).toEqual(['Full song']);
+        expect(result.filteredByDuration).toBe(1);
+    });
+
+    it('keeps tracks with no duration to avoid dropping incomplete Spotify data', () => {
+        const result = spotifyService.filterTracks([
+            createMockTrack('Track without duration'),
+        ], { minDurationMs: 90000 });
+
+        expect(result.tracks.map(track => track.name)).toEqual(['Track without duration']);
+        expect(result.filteredByDuration).toBe(0);
+    });
+
+    it('uses the default duration when the environment variable is unset', () => {
+        delete process.env.MIN_TRACK_DURATION_MS;
+
+        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+
+        expect(result.tracks).toHaveLength(0);
+    });
+
+    it('uses the default duration when the environment variable is invalid', () => {
+        process.env.MIN_TRACK_DURATION_MS = 'not-a-number';
+
+        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+
+        expect(result.tracks).toHaveLength(0);
+    });
+
+    it('uses the default duration when the environment variable is empty', () => {
+        process.env.MIN_TRACK_DURATION_MS = '';
+
+        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+
+        expect(result.tracks).toHaveLength(0);
+    });
+
+    it('disables duration filtering when the environment variable is zero', () => {
+        process.env.MIN_TRACK_DURATION_MS = '0';
+
+        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 1)]);
+
+        expect(result.tracks.map(track => track.name)).toEqual(['Short interlude']);
+        expect(result.filteredByDuration).toBe(0);
+    });
+
+    it('reports tracks matching both filters as name exclusions', () => {
+        const result = spotifyService.filterTracks([
+            createMockTrack('Short Song (Instrumental)', 1),
+        ], { minDurationMs: 90000 });
+
+        expect(result.tracks).toHaveLength(0);
+        expect(result.filteredByName).toBe(1);
+        expect(result.filteredByDuration).toBe(0);
     });
 });

--- a/packages/backend/src/services/spotify.ts
+++ b/packages/backend/src/services/spotify.ts
@@ -21,10 +21,23 @@ export interface SpotifyTrack {
     name: string;
     artists: { name: string }[];
     album: { name: string; images: { url: string }[] };
+    duration_ms?: number;
     external_ids?: {
         isrc?: string;
     };
 }
+
+export interface TrackFilterOptions {
+    minDurationMs?: number;
+}
+
+export interface TrackFilterResult {
+    tracks: SpotifyTrack[];
+    filteredByDuration: number;
+    filteredByName: number;
+}
+
+const DEFAULT_MIN_TRACK_DURATION_MS = 90000;
 
 export class SpotifyService {
     private clientId: string;
@@ -146,6 +159,41 @@ export class SpotifyService {
             }
             return true; // Include this track
         });
+    }
+
+    filterShortTracks(tracks: SpotifyTrack[], minDurationMs: number): SpotifyTrack[] {
+        if (minDurationMs === 0) {
+            return tracks;
+        }
+
+        return tracks.filter(track => track.duration_ms === undefined || track.duration_ms >= minDurationMs);
+    }
+
+    filterTracks(tracks: SpotifyTrack[], options: TrackFilterOptions = {}): TrackFilterResult {
+        const minDurationMs = options.minDurationMs ?? this.getMinTrackDurationMs();
+        const tracksWithoutInstrumentals = this.filterInstrumentalTracks(tracks);
+        const filteredTracks = this.filterShortTracks(tracksWithoutInstrumentals, minDurationMs);
+
+        return {
+            tracks: filteredTracks,
+            filteredByName: tracks.length - tracksWithoutInstrumentals.length,
+            filteredByDuration: tracksWithoutInstrumentals.length - filteredTracks.length,
+        };
+    }
+
+    private getMinTrackDurationMs(): number {
+        const configuredDuration = process.env.MIN_TRACK_DURATION_MS;
+
+        if (!configuredDuration || configuredDuration.trim() === '') {
+            return DEFAULT_MIN_TRACK_DURATION_MS;
+        }
+
+        const parsedDuration = Number(configuredDuration);
+        if (!Number.isFinite(parsedDuration) || parsedDuration < 0) {
+            return DEFAULT_MIN_TRACK_DURATION_MS;
+        }
+
+        return parsedDuration;
     }
 
     async createPlaylist(

--- a/packages/backend/src/utils/metrics.ts
+++ b/packages/backend/src/utils/metrics.ts
@@ -22,6 +22,12 @@ export const metrics = {
         labelNames: ['user_count'],
         registers: [registry],
     }),
+    tracksFiltered: new Counter({
+        name: 'reblend_tracks_filtered_total',
+        help: 'Total number of tracks filtered from blends',
+        labelNames: ['reason'],
+        registers: [registry],
+    }),
     activeUsers: new Gauge({
         name: 'reblend_active_users',
         help: 'Number of active users currently registered',


### PR DESCRIPTION
Closes #199

42秒程度のアルバム収録インスト（インタールード / SE）がブレンドに混ざる問題への対処。既存の除外は曲名パターンマッチだけで、曲名に手がかりのない短尺トラックは素通りしていた。

## 変更

- `SpotifyTrack` に `duration_ms` を追加（`getPlaylistTracks` は `fields` で絞っていて返らないため optional）
- 尺による除外 `filterShortTracks` を追加し、曲名フィルタと合わせて適用する入口 `filterTracks` を用意
- 閾値は `MIN_TRACK_DURATION_MS`（既定 90000 = 90秒）。未設定・空・不正値は既定へフォールバック、`0` で除外を無効化
- `duration_ms` が欠損しているトラックは除外しない（データ欠損で正規曲を落とさないため）
- 除外件数を理由別にログと `reblend_tracks_filtered_total{reason="duration"|"name"}` へ記録
- `.config/.env.example` / Helm values / deployment.yaml / README を更新、chart version を 0.5.0 へ

## テスト

境界値（閾値ちょうど / 未満 / 超過 / `duration_ms` 欠損）と環境変数の扱い（未設定 / 不正値 / 空 / `0`）を追加。backend 36 tests passed。

## 補足

90秒が妥当かは本 PR の検証対象ではない。まずログとメトリクスで実データを見ながら調整できる形にすることが目的で、閾値は環境変数で変更できる。曲名パターンの拡充は #200 で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)