### PR TITLE
feat(backend): add auto update settings schema and api

### DIFF
--- a/packages/backend/src/config/database.test.ts
+++ b/packages/backend/src/config/database.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    connect: vi.fn(),
+    query: vi.fn(),
+    release: vi.fn(),
+}));
+
+vi.mock('pg', () => ({
+    Pool: class {
+        connect = mocks.connect;
+    },
+}));
+
+vi.mock('../utils/logger', () => ({
+    logger: {
+        warn: vi.fn(),
+    },
+}));
+
+import { initDatabase } from './database';
+
+describe('initDatabase', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.connect.mockResolvedValue({ query: mocks.query, release: mocks.release });
+        mocks.query.mockResolvedValue(undefined);
+    });
+
+    it('applies automatic update columns and its partial index idempotently', async () => {
+        await initDatabase();
+        await initDatabase();
+
+        expect(mocks.query).toHaveBeenCalledTimes(2);
+        for (const [statement] of mocks.query.mock.calls) {
+            expect(statement).toContain('ADD COLUMN IF NOT EXISTS auto_update_enabled BOOLEAN DEFAULT false');
+            expect(statement).toContain("ADD COLUMN IF NOT EXISTS auto_update_sort_mode VARCHAR(20) DEFAULT 'shuffle'");
+            expect(statement).toContain('ADD COLUMN IF NOT EXISTS last_auto_updated_at TIMESTAMP');
+            expect(statement).toContain('ADD COLUMN IF NOT EXISTS last_auto_update_status VARCHAR(50)');
+            expect(statement).toContain('ADD COLUMN IF NOT EXISTS last_auto_update_error TEXT');
+            expect(statement).toContain('CREATE INDEX IF NOT EXISTS idx_playlists_auto_update');
+            expect(statement).toContain('WHERE auto_update_enabled');
+        }
+        expect(mocks.release).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/backend/src/config/database.ts
+++ b/packages/backend/src/config/database.ts
@@ -71,6 +71,11 @@ export async function initDatabase(): Promise<void> {
         owner_id INTEGER REFERENCES users(id),
         spotify_playlist_id VARCHAR(255),
         status VARCHAR(50) DEFAULT 'pending',
+        auto_update_enabled BOOLEAN DEFAULT false,
+        auto_update_sort_mode VARCHAR(20) DEFAULT 'shuffle',
+        last_auto_updated_at TIMESTAMP,
+        last_auto_update_status VARCHAR(50),
+        last_auto_update_error TEXT,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
@@ -94,6 +99,17 @@ export async function initDatabase(): Promise<void> {
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         UNIQUE(playlist_id, user_id)
       );
+
+      ALTER TABLE playlists
+        ADD COLUMN IF NOT EXISTS auto_update_enabled BOOLEAN DEFAULT false,
+        ADD COLUMN IF NOT EXISTS auto_update_sort_mode VARCHAR(20) DEFAULT 'shuffle',
+        ADD COLUMN IF NOT EXISTS last_auto_updated_at TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS last_auto_update_status VARCHAR(50),
+        ADD COLUMN IF NOT EXISTS last_auto_update_error TEXT;
+
+      CREATE INDEX IF NOT EXISTS idx_playlists_auto_update
+        ON playlists (auto_update_enabled)
+        WHERE auto_update_enabled;
     `);
     console.log('Database tables initialized');
   } finally {

--- a/packages/backend/src/routes/playlists-auto-update.test.ts
+++ b/packages/backend/src/routes/playlists-auto-update.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express, { NextFunction, Request, Response } from 'express';
+import { AddressInfo } from 'node:net';
+
+const mocks = vi.hoisted(() => ({
+    query: vi.fn(),
+}));
+
+vi.mock('../config/database', () => ({
+    pool: { query: mocks.query },
+}));
+
+vi.mock('../utils/auth', () => ({
+    requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+        req.authUser = { id: 1, spotifyId: 'owner-spotify-id' };
+        next();
+    },
+}));
+
+vi.mock('../services/spotify', () => ({
+    spotifyService: {},
+}));
+
+vi.mock('../services/playlist-generation', () => ({
+    generatePlaylist: vi.fn(),
+}));
+
+vi.mock('../services/spotify-token', () => ({
+    getValidAccessToken: vi.fn(),
+}));
+
+vi.mock('../utils/http', () => ({
+    rateLimit: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../utils/metrics', () => ({
+    metrics: {
+        playlistCreated: { inc: vi.fn() },
+        blendExecuted: { inc: vi.fn() },
+    },
+}));
+
+vi.mock('../utils/logger', () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+import playlistsRouter from './playlists';
+
+async function request(method: string, path: string, body?: unknown): Promise<{ status: number; body: unknown }> {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/playlists', playlistsRouter);
+    const server = app.listen(0, '127.0.0.1');
+
+    try {
+        await new Promise<void>((resolve) => server.once('listening', resolve));
+        const { port } = server.address() as AddressInfo;
+        const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+            method,
+            headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        return { status: response.status, body: await response.json() };
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close(error => error ? reject(error) : resolve());
+        });
+    }
+}
+
+describe('playlist automatic update routes', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.query.mockReset();
+    });
+
+    it('rejects updates from users who do not own the playlist', async () => {
+        mocks.query.mockResolvedValueOnce({ rows: [] });
+
+        await expect(request('PATCH', '/api/playlists/12/auto-update', { enabled: true })).resolves.toEqual({
+            status: 403,
+            body: { error: 'Only the owner can update automatic updates' },
+        });
+        expect(mocks.query).toHaveBeenCalledWith(
+            'SELECT * FROM playlists WHERE id = $1 AND owner_id = $2',
+            ['12', 1]
+        );
+    });
+
+    it('rejects a missing or non-boolean enabled value before querying the database', async () => {
+        await expect(request('PATCH', '/api/playlists/12/auto-update')).resolves.toEqual({
+            status: 400,
+            body: { error: 'Auto update enabled must be a boolean' },
+        });
+        await expect(request('PATCH', '/api/playlists/12/auto-update', {})).resolves.toEqual({
+            status: 400,
+            body: { error: 'Auto update enabled must be a boolean' },
+        });
+        await expect(request('PATCH', '/api/playlists/12/auto-update', { enabled: 'true' })).resolves.toEqual({
+            status: 400,
+            body: { error: 'Auto update enabled must be a boolean' },
+        });
+        expect(mocks.query).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid sort mode before querying the database', async () => {
+        await expect(request('PATCH', '/api/playlists/12/auto-update', {
+            enabled: true,
+            sortMode: 'alphabetical',
+        })).resolves.toEqual({
+            status: 400,
+            body: { error: 'Invalid sort mode' },
+        });
+        expect(mocks.query).not.toHaveBeenCalled();
+    });
+
+    it('does not enable automatic updates before the playlist has been generated', async () => {
+        mocks.query.mockResolvedValueOnce({ rows: [{ id: 12, status: 'pending' }] });
+
+        await expect(request('PATCH', '/api/playlists/12/auto-update', { enabled: true })).resolves.toEqual({
+            status: 400,
+            body: { error: 'Playlist must be generated before enabling automatic updates' },
+        });
+        expect(mocks.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('updates settings for the owner and returns the persisted values', async () => {
+        mocks.query
+            .mockResolvedValueOnce({ rows: [{ id: 12, status: 'generated' }] })
+            .mockResolvedValueOnce({
+                rows: [{
+                    auto_update_enabled: true,
+                    auto_update_sort_mode: 'smart',
+                    last_auto_updated_at: null,
+                    last_auto_update_status: null,
+                }],
+            });
+
+        await expect(request('PATCH', '/api/playlists/12/auto-update', {
+            enabled: true,
+            sortMode: 'smart',
+        })).resolves.toEqual({
+            status: 200,
+            body: {
+                autoUpdateEnabled: true,
+                autoUpdateSortMode: 'smart',
+                lastAutoUpdatedAt: null,
+                lastAutoUpdateStatus: null,
+            },
+        });
+    });
+
+    it('includes automatic update state in playlist lists', async () => {
+        mocks.query.mockResolvedValueOnce({
+            rows: [{
+                id: 12,
+                name: 'My ReBlend',
+                description: 'A blended playlist',
+                owner_id: 1,
+                owner_name: 'Owner',
+                spotify_playlist_id: 'spotify-playlist',
+                status: 'generated',
+                auto_update_enabled: true,
+                auto_update_sort_mode: 'shuffle',
+                last_auto_updated_at: '2026-08-15T00:00:00.000Z',
+                last_auto_update_status: 'success',
+                role: 'owner',
+                created_at: '2026-08-01T00:00:00.000Z',
+            }],
+        });
+
+        await expect(request('GET', '/api/playlists')).resolves.toEqual({
+            status: 200,
+            body: [expect.objectContaining({
+                autoUpdateEnabled: true,
+                autoUpdateSortMode: 'shuffle',
+                lastAutoUpdatedAt: '2026-08-15T00:00:00.000Z',
+                lastAutoUpdateStatus: 'success',
+            })],
+        });
+    });
+
+    it('includes automatic update state in playlist details', async () => {
+        mocks.query
+            .mockResolvedValueOnce({ rows: [{ role: 'owner' }] })
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 12,
+                    name: 'My ReBlend',
+                    description: 'A blended playlist',
+                    owner_id: 1,
+                    owner_name: 'Owner',
+                    spotify_playlist_id: 'spotify-playlist',
+                    status: 'generated',
+                    auto_update_enabled: true,
+                    auto_update_sort_mode: 'smart',
+                    last_auto_updated_at: '2026-08-15T00:00:00.000Z',
+                    last_auto_update_status: 'partial',
+                    created_at: '2026-08-01T00:00:00.000Z',
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] });
+
+        await expect(request('GET', '/api/playlists/12')).resolves.toEqual({
+            status: 200,
+            body: expect.objectContaining({
+                autoUpdateEnabled: true,
+                autoUpdateSortMode: 'smart',
+                lastAutoUpdatedAt: '2026-08-15T00:00:00.000Z',
+                lastAutoUpdateStatus: 'partial',
+            }),
+        });
+    });
+});

--- a/packages/backend/src/routes/playlists.ts
+++ b/packages/backend/src/routes/playlists.ts
@@ -74,7 +74,8 @@ router.get('/', async (req: Request, res: Response) => {
 
         const result = await pool.query(
             `SELECT DISTINCT p.id, p.name, p.description, p.owner_id, p.spotify_playlist_id, 
-              p.status, p.created_at, u.display_name as owner_name,
+              p.status, p.auto_update_enabled, p.auto_update_sort_mode,
+              p.last_auto_updated_at, p.last_auto_update_status, p.created_at, u.display_name as owner_name,
               pm.role
        FROM playlists p
        JOIN playlist_members pm ON p.id = pm.playlist_id
@@ -92,6 +93,10 @@ router.get('/', async (req: Request, res: Response) => {
             ownerName: p.owner_name,
             spotifyPlaylistId: p.spotify_playlist_id,
             status: p.status,
+            autoUpdateEnabled: p.auto_update_enabled,
+            autoUpdateSortMode: p.auto_update_sort_mode,
+            lastAutoUpdatedAt: p.last_auto_updated_at,
+            lastAutoUpdateStatus: p.last_auto_update_status,
             role: p.role,
             createdAt: p.created_at,
         })));
@@ -158,6 +163,10 @@ router.get('/:id', async (req: Request, res: Response) => {
             ownerName: playlist.owner_name,
             spotifyPlaylistId: playlist.spotify_playlist_id,
             status: playlist.status,
+            autoUpdateEnabled: playlist.auto_update_enabled,
+            autoUpdateSortMode: playlist.auto_update_sort_mode,
+            lastAutoUpdatedAt: playlist.last_auto_updated_at,
+            lastAutoUpdateStatus: playlist.last_auto_update_status,
             createdAt: playlist.created_at,
             userRole: memberCheck.rows[0].role,
             members: membersResult.rows.map(m => ({
@@ -242,6 +251,58 @@ router.get('/:id/tracks', async (req: Request, res: Response) => {
     } catch (error) {
         logger.error({ err: error, playlistId: req.params.id }, 'Get playlist tracks error');
         res.status(500).json({ error: 'Failed to get playlist tracks' });
+    }
+});
+
+// Enable or disable daily automatic updates for a generated playlist
+router.patch('/:id/auto-update', async (req: Request, res: Response) => {
+    try {
+        const userId = req.authUser!.id;
+        const { id } = req.params;
+        const { enabled, sortMode } = (req.body ?? {}) as { enabled?: unknown; sortMode?: unknown };
+
+        if (typeof enabled !== 'boolean') {
+            return res.status(400).json({ error: 'Auto update enabled must be a boolean' });
+        }
+        if (sortMode !== undefined && sortMode !== 'shuffle' && sortMode !== 'smart') {
+            return res.status(400).json({ error: 'Invalid sort mode' });
+        }
+
+        // Check if user is owner
+        const playlistResult = await pool.query(
+            'SELECT * FROM playlists WHERE id = $1 AND owner_id = $2',
+            [id, userId]
+        );
+
+        if (playlistResult.rows.length === 0) {
+            return res.status(403).json({ error: 'Only the owner can update automatic updates' });
+        }
+
+        const playlist = playlistResult.rows[0];
+        if (enabled && playlist.status !== 'generated') {
+            return res.status(400).json({ error: 'Playlist must be generated before enabling automatic updates' });
+        }
+
+        const updatedResult = await pool.query(
+            `UPDATE playlists
+             SET auto_update_enabled = $1,
+                 auto_update_sort_mode = COALESCE($2, auto_update_sort_mode),
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = $3
+             RETURNING auto_update_enabled, auto_update_sort_mode, last_auto_updated_at, last_auto_update_status`,
+            [enabled, sortMode, id]
+        );
+        const updated = updatedResult.rows[0];
+
+        res.json({
+            autoUpdateEnabled: updated.auto_update_enabled,
+            autoUpdateSortMode: updated.auto_update_sort_mode,
+            lastAutoUpdatedAt: updated.last_auto_updated_at,
+            lastAutoUpdateStatus: updated.last_auto_update_status,
+        });
+    } catch (error) {
+        logger.error({ err: error, playlistId: req.params.id }, 'Update automatic playlist settings error');
+        res.status(500).json({ error: 'Failed to update automatic playlist settings' });
     }
 });
 

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -44,6 +44,10 @@ export interface Playlist {
     ownerName: string;
     spotifyPlaylistId: string | null;
     status: 'pending' | 'generated';
+    autoUpdateEnabled: boolean;
+    autoUpdateSortMode: SortMode;
+    lastAutoUpdatedAt: string | null;
+    lastAutoUpdateStatus: string | null;
     role: 'owner' | 'member';
     createdAt: string;
 }
@@ -91,6 +95,14 @@ export const playlistApi = {
             spotifyUrl: string;
             trackCount: number;
         }>(`/api/playlists/${id}/generate`, { sortMode }),
+
+    setAutoUpdate: (id: number, settings: { enabled: boolean; sortMode?: SortMode }) =>
+        api.patch<{
+            autoUpdateEnabled: boolean;
+            autoUpdateSortMode: SortMode;
+            lastAutoUpdatedAt: string | null;
+            lastAutoUpdateStatus: string | null;
+        }>(`/api/playlists/${id}/auto-update`, settings),
 
     delete: (id: number, deleteFromSpotify: boolean = false) =>
         api.delete<{ message: string }>(`/api/playlists/${id}?deleteFromSpotify=${deleteFromSpotify}`),


### PR DESCRIPTION
Closes #202

日次自動更新（#14 / #203）をプレイリスト単位のオプトインにするための、設定の永続化と切り替え API。スケジューラ本体は #203、UI は #204 で行う。

## 変更

- `playlists` に `auto_update_enabled` / `auto_update_sort_mode` / `last_auto_updated_at` / `last_auto_update_status` / `last_auto_update_error` を追加（`ALTER TABLE ... ADD COLUMN IF NOT EXISTS` で既存 DB にも冪等に適用）
- 有効なプレイリストだけを引くための部分インデックスを追加
- `PATCH /api/playlists/:id/auto-update` を追加。オーナーのみ（403）、未生成プレイリストの有効化は 400、`enabled` と `sortMode` のバリデーションあり
- `GET /api/playlists` と `GET /api/playlists/:id` に自動更新の状態を追加
- frontend は型と `playlistApi.setAutoUpdate()` のみ（画面の変更なし）

## テスト

認可（非オーナー 403）、バリデーション（`enabled` 非 boolean / 不正 sortMode を DB 問い合わせ前に弾く）、未生成での有効化 400、正常系の永続値、GET 系への反映、DDL の冪等性。backend 44 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)