### PR TITLE
feat(frontend): add auto update toggle to playlist detail

### DIFF
--- a/packages/frontend/src/pages/PlaylistDetailPage.css
+++ b/packages/frontend/src/pages/PlaylistDetailPage.css
@@ -223,6 +223,75 @@
     font-size: var(--font-size-sm);
 }
 
+/* Auto update section */
+.auto-update-card {
+    padding: var(--spacing-xl);
+}
+
+.auto-update-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+}
+
+.auto-update-toggle input {
+    position: absolute;
+    opacity: 0;
+}
+
+.auto-update-toggle input:disabled + .auto-update-toggle-track {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.auto-update-toggle-track {
+    display: inline-flex;
+    align-items: center;
+    width: 44px;
+    height: 24px;
+    padding: 2px;
+    background: var(--color-border);
+    border-radius: 999px;
+    transition: background var(--transition-fast);
+}
+
+.auto-update-toggle input:checked + .auto-update-toggle-track {
+    background: var(--color-primary);
+}
+
+.auto-update-toggle-thumb {
+    width: 20px;
+    height: 20px;
+    background: white;
+    border-radius: 50%;
+    transform: translateX(0);
+    transition: transform var(--transition-fast);
+}
+
+.auto-update-toggle input:checked + .auto-update-toggle-track .auto-update-toggle-thumb {
+    transform: translateX(20px);
+}
+
+.auto-update-card .sort-mode-selector {
+    margin-top: var(--spacing-xl);
+}
+
+.auto-update-hint,
+.auto-update-status,
+.auto-update-readonly {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    margin-top: var(--spacing-md);
+}
+
+.auto-update-warning {
+    color: var(--color-error);
+    font-size: var(--font-size-sm);
+    margin-top: var(--spacing-sm);
+}
+
 .button-spinner {
     width: 18px;
     height: 18px;

--- a/packages/frontend/src/pages/PlaylistDetailPage.test.tsx
+++ b/packages/frontend/src/pages/PlaylistDetailPage.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PlaylistDetail } from '../services/api';
+import PlaylistDetailPage from './PlaylistDetailPage';
+
+const apiMocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    getTracks: vi.fn(),
+    setAutoUpdate: vi.fn(),
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+    useAuth: () => ({ user: { id: 1 } }),
+}));
+
+vi.mock('../services/api', async () => {
+    const actual = await vi.importActual<typeof import('../services/api')>('../services/api');
+    return {
+        ...actual,
+        playlistApi: {
+            ...actual.playlistApi,
+            get: apiMocks.get,
+            getTracks: apiMocks.getTracks,
+            setAutoUpdate: apiMocks.setAutoUpdate,
+        },
+    };
+});
+
+function createPlaylist(overrides: Partial<PlaylistDetail> = {}): PlaylistDetail {
+    return {
+        id: 1,
+        name: '週末のブレンド',
+        description: '',
+        ownerId: 1,
+        ownerName: 'オーナー',
+        spotifyPlaylistId: null,
+        status: 'generated',
+        autoUpdateEnabled: false,
+        autoUpdateSortMode: 'shuffle',
+        lastAutoUpdatedAt: null,
+        lastAutoUpdateStatus: null,
+        role: 'owner',
+        userRole: 'owner',
+        createdAt: '2026-08-15T00:00:00.000Z',
+        members: [{ id: 1, spotifyId: 'owner', displayName: 'オーナー', role: 'owner' }],
+        pendingInvitations: [],
+        ...overrides,
+    };
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/playlists/1']}>
+            <Routes>
+                <Route path="/playlists/:id" element={<PlaylistDetailPage />} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('PlaylistDetailPage auto update settings', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        apiMocks.getTracks.mockResolvedValue({ data: { tracks: [] } });
+    });
+
+    it('allows an owner to enable automatic updates after the API responds', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist() });
+        apiMocks.setAutoUpdate.mockResolvedValue({
+            data: {
+                autoUpdateEnabled: true,
+                autoUpdateSortMode: 'shuffle',
+                lastAutoUpdatedAt: null,
+                lastAutoUpdateStatus: null,
+            },
+        });
+
+        renderPage();
+
+        const toggle = await screen.findByRole('switch', { name: '毎日自動で再生成する' });
+        fireEvent.click(toggle);
+
+        await waitFor(() => {
+            expect(apiMocks.setAutoUpdate).toHaveBeenCalledWith(1, {
+                enabled: true,
+                sortMode: 'shuffle',
+            });
+        });
+        expect(toggle).toBeChecked();
+    });
+
+    it('shows automatic update settings as read-only for a member', async () => {
+        apiMocks.get.mockResolvedValue({
+            data: createPlaylist({ userRole: 'member', role: 'member', autoUpdateEnabled: true }),
+        });
+
+        renderPage();
+
+        expect(await screen.findByText(/自動更新は有効です/)).toBeInTheDocument();
+        expect(screen.queryByRole('switch', { name: '毎日自動で再生成する' })).not.toBeInTheDocument();
+    });
+
+    it('disables automatic updates until the playlist has been generated', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist({ status: 'pending' }) });
+
+        renderPage();
+
+        expect(await screen.findByRole('switch', { name: '毎日自動で再生成する' })).toBeDisabled();
+        expect(screen.getByText('まず一度生成してください')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/packages/frontend/src/pages/PlaylistDetailPage.tsx
@@ -38,6 +38,10 @@ export default function PlaylistDetailPage() {
     } | null>(null);
     const [sortMode, setSortMode] = useState<SortMode>('shuffle');
 
+    // Auto update state
+    const [isUpdatingAutoUpdate, setIsUpdatingAutoUpdate] = useState(false);
+    const [autoUpdateError, setAutoUpdateError] = useState<string | null>(null);
+
     // Delete state
     const [isDeleting, setIsDeleting] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -156,6 +160,37 @@ export default function PlaylistDetailPage() {
             setIsDeleting(false);
             setShowDeleteConfirm(false);
         }
+    };
+
+    const handleAutoUpdate = async (enabled: boolean, autoUpdateSortMode: SortMode) => {
+        if (!id || !playlist || isUpdatingAutoUpdate) return;
+
+        setIsUpdatingAutoUpdate(true);
+        setAutoUpdateError(null);
+
+        try {
+            const response = await playlistApi.setAutoUpdate(parseInt(id), {
+                enabled,
+                sortMode: autoUpdateSortMode,
+            });
+            setPlaylist(currentPlaylist => currentPlaylist ? {
+                ...currentPlaylist,
+                ...response.data,
+            } : currentPlaylist);
+        } catch (err) {
+            console.error('Failed to update auto update settings:', err);
+            setAutoUpdateError('自動更新の設定に失敗しました');
+        } finally {
+            setIsUpdatingAutoUpdate(false);
+        }
+    };
+
+    const formatAutoUpdateTime = (value: string) => {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return null;
+
+        const twoDigits = (number: number) => String(number).padStart(2, '0');
+        return `${date.getFullYear()}/${twoDigits(date.getMonth() + 1)}/${twoDigits(date.getDate())} ${twoDigits(date.getHours())}:${twoDigits(date.getMinutes())}`;
     };
 
     if (isLoading) {
@@ -441,6 +476,91 @@ export default function PlaylistDetailPage() {
                             </div>
                         </section>
                     )}
+
+                    {/* Auto update section */}
+                    <section className="detail-section">
+                        <h2 className="section-title">
+                            <span className="section-icon">🗓️</span>
+                            自動更新
+                        </h2>
+                        <div className="auto-update-card card">
+                            {isOwner ? (
+                                <>
+                                    <label className="auto-update-toggle">
+                                        <input
+                                            type="checkbox"
+                                            role="switch"
+                                            checked={playlist.autoUpdateEnabled}
+                                            disabled={playlist.status !== 'generated' || isUpdatingAutoUpdate}
+                                            onChange={(event) => handleAutoUpdate(event.target.checked, playlist.autoUpdateSortMode)}
+                                        />
+                                        <span className="auto-update-toggle-track" aria-hidden="true">
+                                            <span className="auto-update-toggle-thumb"></span>
+                                        </span>
+                                        <span>毎日自動で再生成する</span>
+                                    </label>
+
+                                    {playlist.status !== 'generated' && (
+                                        <p className="auto-update-hint">まず一度生成してください</p>
+                                    )}
+
+                                    <div className="sort-mode-selector">
+                                        <label className="sort-mode-label">自動更新時の曲の並び順:</label>
+                                        <div className="sort-mode-options">
+                                            <label className={`sort-mode-option ${playlist.autoUpdateSortMode === 'shuffle' ? 'selected' : ''}`}>
+                                                <input
+                                                    type="radio"
+                                                    name="autoUpdateSortMode"
+                                                    value="shuffle"
+                                                    checked={playlist.autoUpdateSortMode === 'shuffle'}
+                                                    disabled={playlist.status !== 'generated' || isUpdatingAutoUpdate}
+                                                    onChange={() => handleAutoUpdate(playlist.autoUpdateEnabled, 'shuffle')}
+                                                />
+                                                <span className="sort-mode-icon">🎲</span>
+                                                <span className="sort-mode-text">
+                                                    <span className="sort-mode-title">シャッフル</span>
+                                                    <span className="sort-mode-desc">ランダムに並べる</span>
+                                                </span>
+                                            </label>
+                                            <label className={`sort-mode-option ${playlist.autoUpdateSortMode === 'smart' ? 'selected' : ''}`}>
+                                                <input
+                                                    type="radio"
+                                                    name="autoUpdateSortMode"
+                                                    value="smart"
+                                                    checked={playlist.autoUpdateSortMode === 'smart'}
+                                                    disabled={playlist.status !== 'generated' || isUpdatingAutoUpdate}
+                                                    onChange={() => handleAutoUpdate(playlist.autoUpdateEnabled, 'smart')}
+                                                />
+                                                <span className="sort-mode-icon">✨</span>
+                                                <span className="sort-mode-text">
+                                                    <span className="sort-mode-title">スマートソート</span>
+                                                    <span className="sort-mode-desc">テンポ・エナジーでスムーズに</span>
+                                                </span>
+                                            </label>
+                                        </div>
+                                    </div>
+
+                                    {autoUpdateError && (
+                                        <div className="form-error">{autoUpdateError}</div>
+                                    )}
+                                </>
+                            ) : (
+                                <p className="auto-update-readonly">
+                                    自動更新は{playlist.autoUpdateEnabled ? '有効' : '無効'}です
+                                    （並び順: {playlist.autoUpdateSortMode === 'smart' ? 'スマートソート' : 'シャッフル'}）
+                                </p>
+                            )}
+
+                            {playlist.lastAutoUpdatedAt && formatAutoUpdateTime(playlist.lastAutoUpdatedAt) && (
+                                <p className="auto-update-status">
+                                    最終自動更新: {formatAutoUpdateTime(playlist.lastAutoUpdatedAt)}
+                                </p>
+                            )}
+                            {playlist.lastAutoUpdateStatus === 'failed' && (
+                                <p className="auto-update-warning">直近の自動更新に失敗しました</p>
+                            )}
+                        </div>
+                    </section>
 
                     {/* Already generated - Spotify link */}
                     {playlist.status === 'generated' && playlist.spotifyPlaylistId && !generateResult && (


### PR DESCRIPTION
Closes #204

プレイリスト詳細画面に日次自動更新（#203）の ON/OFF を追加する。API は #202 で追加済み。

## 変更

- 生成カードの下に「自動更新」セクションを追加。トグルと並び順（shuffle / smart）の選択
- 操作できるのはオーナーのみ。メンバーには状態が読み取り専用で表示される
- 未生成プレイリストではトグルを無効化（API 側の 400 と挙動を揃えている）
- 最終自動更新時刻と、直近が失敗した場合の警告を表示
- 楽観更新はせず、API 応答後に state を更新する。処理中は二重送信を防ぐ

## 補足

`lastAutoUpdateStatus` は `failed` のみを特別扱いし、未知の値は無視する。#203 で `partial` が増えるため、先に UI がマージされても壊れないようにしている。

frontend 4 tests passed（オーナーの操作、メンバーの読み取り専用、未生成での無効化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)