### PR TITLE
feat(backend): detect and persist revoked spotify tokens

### DIFF
--- a/packages/backend/src/config/database.ts
+++ b/packages/backend/src/config/database.ts
@@ -60,6 +60,8 @@ export async function initDatabase(): Promise<void> {
         access_token TEXT,
         refresh_token TEXT,
         token_expires_at TIMESTAMP,
+        token_status VARCHAR(20) DEFAULT 'active',
+        token_invalidated_at TIMESTAMP,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
@@ -110,6 +112,9 @@ export async function initDatabase(): Promise<void> {
       CREATE INDEX IF NOT EXISTS idx_playlists_auto_update
         ON playlists (auto_update_enabled)
         WHERE auto_update_enabled;
+
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS token_status VARCHAR(20) DEFAULT 'active';
+      ALTER TABLE users ADD COLUMN IF NOT EXISTS token_invalidated_at TIMESTAMP;
     `);
     console.log('Database tables initialized');
   } finally {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,6 +5,7 @@ import { Server } from 'http';
 import path from 'path';
 import dotenv from 'dotenv';
 import { initDatabase, pool } from './config/database';
+import { refreshTokenInvalidUsersGauge } from './services/spotify-token';
 import { logger, requestLogger } from './utils/logger';
 import { startMetricsServer, metrics } from './utils/metrics';
 import { blockSensitivePaths, createCorsMiddleware, rateLimit, securityHeaders } from './utils/http';
@@ -107,6 +108,7 @@ app.use((err: Error, _req: express.Request, res: express.Response, _next: expres
 async function start() {
     try {
         await initDatabase();
+        await refreshTokenInvalidUsersGauge();
 
         // Start Metrics Server
         metricsServer = startMetricsServer(METRICS_PORT);

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -10,8 +10,9 @@ import {
     setOAuthStateCookie,
     verifyOAuthState
 } from '../utils/auth';
-import { decryptSecret, encryptSecret } from '../utils/crypto';
+import { encryptSecret } from '../utils/crypto';
 import { rateLimit } from '../utils/http';
+import { getValidAccessToken, refreshTokenInvalidUsersGauge } from '../services/spotify-token';
 
 const router: Router = Router();
 
@@ -46,8 +47,8 @@ router.post('/callback', rateLimit({ windowMs: 60_000, max: 10, keyPrefix: 'auth
 
         // Upsert user in database
         const result = await pool.query(
-            `INSERT INTO users (spotify_id, display_name, email, access_token, refresh_token, token_expires_at, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)
+            `INSERT INTO users (spotify_id, display_name, email, access_token, refresh_token, token_expires_at, token_status, token_invalidated_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, 'active', NULL, CURRENT_TIMESTAMP)
        ON CONFLICT (spotify_id) 
        DO UPDATE SET 
          display_name = EXCLUDED.display_name,
@@ -55,6 +56,8 @@ router.post('/callback', rateLimit({ windowMs: 60_000, max: 10, keyPrefix: 'auth
          access_token = EXCLUDED.access_token,
          refresh_token = COALESCE(EXCLUDED.refresh_token, users.refresh_token),
          token_expires_at = EXCLUDED.token_expires_at,
+         token_status = 'active',
+         token_invalidated_at = NULL,
          updated_at = CURRENT_TIMESTAMP
        RETURNING id, spotify_id, display_name, email`,
             [
@@ -66,6 +69,8 @@ router.post('/callback', rateLimit({ windowMs: 60_000, max: 10, keyPrefix: 'auth
                 expiresAt
             ]
         );
+
+        await refreshTokenInvalidUsersGauge();
 
         const user = result.rows[0];
         setAuthCookie(res, { id: user.id, spotifyId: user.spotify_id });
@@ -91,9 +96,9 @@ router.post('/refresh', requireAuth, rateLimit({ windowMs: 60_000, max: 20, keyP
     try {
         const userId = req.authUser!.id;
 
-        // Get user's refresh token
+        // Get user's token data. The shared helper owns refresh-state persistence.
         const userResult = await pool.query(
-            'SELECT refresh_token FROM users WHERE id = $1',
+            'SELECT id, access_token, refresh_token, token_expires_at, token_status FROM users WHERE id = $1',
             [userId]
         );
 
@@ -101,25 +106,15 @@ router.post('/refresh', requireAuth, rateLimit({ windowMs: 60_000, max: 20, keyP
             return res.status(404).json({ error: 'User not found' });
         }
 
-        const refreshToken = decryptSecret(userResult.rows[0].refresh_token);
-        if (!refreshToken) {
+        const { accessToken, refreshTokenUnavailable, expiresAt } = await getValidAccessToken(userResult.rows[0], {
+            forceRefresh: true,
+        });
+        if (refreshTokenUnavailable) {
             return res.status(400).json({ error: 'Refresh token not available' });
         }
-
-        // Get new tokens from Spotify
-        const tokens = await spotifyService.refreshToken(refreshToken);
-        const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
-
-        // Update user's tokens
-        await pool.query(
-            `UPDATE users SET 
-         access_token = $1, 
-         refresh_token = COALESCE($2, refresh_token),
-         token_expires_at = $3,
-         updated_at = CURRENT_TIMESTAMP
-       WHERE id = $4`,
-            [encryptSecret(tokens.access_token), encryptSecret(tokens.refresh_token), expiresAt, userId]
-        );
+        if (!accessToken || !expiresAt) {
+            return res.status(500).json({ error: 'Token refresh failed' });
+        }
 
         res.json({
             expiresAt: expiresAt.toISOString(),
@@ -136,7 +131,7 @@ router.get('/me', requireAuth, async (req: Request, res: Response) => {
         const userId = req.authUser!.id;
 
         const result = await pool.query(
-            'SELECT id, spotify_id, display_name, email FROM users WHERE id = $1',
+            'SELECT id, spotify_id, display_name, email, token_status FROM users WHERE id = $1',
             [userId]
         );
 
@@ -150,6 +145,7 @@ router.get('/me', requireAuth, async (req: Request, res: Response) => {
             spotifyId: user.spotify_id,
             displayName: user.display_name,
             email: user.email,
+            tokenStatus: user.token_status,
         });
     } catch (error) {
         console.error('Get user error:', error);

--- a/packages/backend/src/routes/playlists.ts
+++ b/packages/backend/src/routes/playlists.ts
@@ -139,7 +139,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 
         // Get members
         const membersResult = await pool.query(
-            `SELECT u.id, u.spotify_id, u.display_name, pm.role
+            `SELECT u.id, u.spotify_id, u.display_name, u.token_status, pm.role
        FROM playlist_members pm
        JOIN users u ON pm.user_id = u.id
        WHERE pm.playlist_id = $1`,
@@ -174,6 +174,7 @@ router.get('/:id', async (req: Request, res: Response) => {
                 spotifyId: m.spotify_id,
                 displayName: m.display_name,
                 role: m.role,
+                tokenStatus: m.token_status,
             })),
             pendingInvitations: invitationsResult.rows.map(i => ({
                 id: i.id,
@@ -221,7 +222,7 @@ router.get('/:id/tracks', async (req: Request, res: Response) => {
 
         // Get user's access token
         const userResult = await pool.query(
-            'SELECT access_token, refresh_token, token_expires_at FROM users WHERE id = $1',
+            'SELECT id, access_token, refresh_token, token_expires_at, token_status FROM users WHERE id = $1',
             [userId]
         );
 
@@ -336,7 +337,7 @@ router.post('/:id/generate', rateLimit({ windowMs: 60_000, max: 6, keyPrefix: 'p
                 'no-tracks': 'No tracks to add to playlist',
                 'owner-token-unavailable': 'Owner access token not available',
             } as const;
-            return res.status(400).json({ error: errors[outcome.reason] });
+            return res.status(400).json({ error: errors[outcome.reason], skippedMembers: outcome.skippedMembers });
         }
 
         res.json({
@@ -344,6 +345,7 @@ router.post('/:id/generate', rateLimit({ windowMs: 60_000, max: 6, keyPrefix: 'p
             spotifyPlaylistId: outcome.spotifyPlaylistId,
             spotifyUrl: outcome.spotifyUrl,
             trackCount: outcome.trackCount,
+            skippedMembers: outcome.skippedMembers,
         });
 
         // Metrics & Logging
@@ -383,7 +385,7 @@ router.delete('/:id', async (req: Request, res: Response) => {
         if (deleteFromSpotify && playlist.spotify_playlist_id) {
             try {
                 const userResult = await pool.query(
-                    'SELECT access_token, refresh_token, token_expires_at FROM users WHERE id = $1',
+                    'SELECT id, access_token, refresh_token, token_expires_at, token_status FROM users WHERE id = $1',
                     [userId]
                 );
 

--- a/packages/backend/src/services/playlist-generation.test.ts
+++ b/packages/backend/src/services/playlist-generation.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     clearPlaylistTracks: vi.fn(),
     followPlaylist: vi.fn(),
     refreshToken: vi.fn(),
+    isRefreshTokenPermanentlyInvalid: vi.fn(),
     tracksFiltered: vi.fn(),
     loggerInfo: vi.fn(),
 }));
@@ -34,6 +35,7 @@ vi.mock('./spotify', () => ({
         followPlaylist: mocks.followPlaylist,
         refreshToken: mocks.refreshToken,
     },
+    isRefreshTokenPermanentlyInvalid: mocks.isRefreshTokenPermanentlyInvalid,
 }));
 
 vi.mock('../utils/auth', () => ({
@@ -69,6 +71,7 @@ import playlistsRouter from '../routes/playlists';
 const member = {
     id: 1,
     spotify_id: 'owner-spotify-id',
+    display_name: 'Owner',
     access_token: 'owner-access-token',
     refresh_token: 'owner-refresh-token',
     token_expires_at: new Date(Date.now() + 60_000),
@@ -130,6 +133,7 @@ describe('generatePlaylist', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.query.mockReset();
+        mocks.isRefreshTokenPermanentlyInvalid.mockReturnValue(false);
         setSuccessfulTrackCollection();
     });
 
@@ -245,7 +249,7 @@ describe('generatePlaylist', () => {
                 spotifyPlaylistId: 'new-spotify-playlist',
                 spotifyUrl: 'https://open.spotify.com/playlist/new-spotify-playlist',
                 trackCount: 1,
-                skippedMembers: [],
+                skippedMembers: [{ id: 1, displayName: 'Owner', reason: 'no-tracks' }],
             },
         });
         expect(mocks.createPlaylist).toHaveBeenCalledWith(
@@ -328,6 +332,52 @@ describe('generatePlaylist', () => {
         });
     });
 
+    it('reports members whose top tracks could not be fetched', async () => {
+        const failedMember = {
+            ...member,
+            id: 2,
+            spotify_id: 'member-spotify-id',
+            display_name: 'Member with unavailable tracks',
+        };
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist('existing-spotify-playlist')] })
+            .mockResolvedValueOnce({ rows: [member, failedMember] })
+            .mockResolvedValueOnce({ rows: [{ spotify_id: 'owner-spotify-id', access_token: 'owner-access-token' }] });
+        mocks.getTopTracks
+            .mockResolvedValueOnce([track])
+            .mockRejectedValueOnce(new Error('Spotify unavailable'));
+
+        await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toMatchObject({
+            ok: true,
+            skippedMembers: [{ id: 2, displayName: 'Member with unavailable tracks', reason: 'no-tracks' }],
+        });
+    });
+
+    it('reports temporary token refresh failures without invalidating the member', async () => {
+        const temporarilyUnavailableMember = {
+            ...member,
+            id: 2,
+            spotify_id: 'member-spotify-id',
+            display_name: 'Member with temporary token failure',
+            token_expires_at: new Date(0),
+            token_status: 'active',
+        };
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist('existing-spotify-playlist')] })
+            .mockResolvedValueOnce({ rows: [member, temporarilyUnavailableMember] })
+            .mockResolvedValueOnce({ rows: [{ spotify_id: 'owner-spotify-id', access_token: 'owner-access-token' }] });
+        mocks.refreshToken.mockRejectedValueOnce(new Error('timeout'));
+
+        await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toMatchObject({
+            ok: true,
+            skippedMembers: [{ id: 2, displayName: 'Member with temporary token failure', reason: 'no-tracks' }],
+        });
+        expect(mocks.isRefreshTokenPermanentlyInvalid).toHaveBeenCalledOnce();
+        expect(mocks.query.mock.calls.some(([sql]) => (
+            typeof sql === 'string' && sql.includes("SET token_status = 'invalid'")
+        ))).toBe(false);
+    });
+
     it('throws a descriptive error when the playlist does not exist', async () => {
         mocks.query.mockResolvedValueOnce({ rows: [] });
 
@@ -366,7 +416,7 @@ describe('generatePlaylist', () => {
         await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toEqual({
             ok: false,
             reason: 'no-tokens',
-            skippedMembers: [],
+            skippedMembers: [{ id: 1, displayName: 'Owner', reason: 'no-tracks' }],
         });
     });
 

--- a/packages/backend/src/services/playlist-generation.test.ts
+++ b/packages/backend/src/services/playlist-generation.test.ts
@@ -151,6 +151,7 @@ describe('generatePlaylist', () => {
             trackCount: 1,
             created: true,
             memberCount: 1,
+            skippedMembers: [],
         });
         expect(mocks.createPlaylist).toHaveBeenCalledWith(
             'owner-access-token',
@@ -244,6 +245,7 @@ describe('generatePlaylist', () => {
                 spotifyPlaylistId: 'new-spotify-playlist',
                 spotifyUrl: 'https://open.spotify.com/playlist/new-spotify-playlist',
                 trackCount: 1,
+                skippedMembers: [],
             },
         });
         expect(mocks.createPlaylist).toHaveBeenCalledWith(
@@ -253,6 +255,77 @@ describe('generatePlaylist', () => {
             'A blended playlist'
         );
         expect(mocks.refreshToken).not.toHaveBeenCalled();
+    });
+
+    it('reports invalid members using their internal user IDs', async () => {
+        const invalidMember = {
+            ...member,
+            id: 2,
+            spotify_id: 'member-spotify-id',
+            display_name: 'Member needing login',
+            token_status: 'invalid',
+        };
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist(null)] })
+            .mockResolvedValueOnce({ rows: [member, invalidMember] })
+            .mockResolvedValueOnce({ rows: [{ spotify_id: 'owner-spotify-id', access_token: 'owner-access-token' }] })
+            .mockResolvedValue({ rows: [] });
+        mocks.createPlaylist.mockResolvedValue({
+            id: 'new-spotify-playlist',
+            external_urls: { spotify: 'https://open.spotify.com/playlist/new-spotify-playlist' },
+        });
+
+        await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toMatchObject({
+            ok: true,
+            skippedMembers: [{ id: 2, displayName: 'Member needing login', reason: 'token-invalid' }],
+        });
+        expect(mocks.getTopTracks).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes skipped members in an unsuccessful generate response', async () => {
+        const invalidOwner = {
+            ...member,
+            display_name: 'Owner needing login',
+            token_status: 'invalid',
+        };
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist(null)] })
+            .mockResolvedValueOnce({ rows: [playlist(null)] })
+            .mockResolvedValueOnce({ rows: [invalidOwner] });
+
+        await expect(postGenerate()).resolves.toEqual({
+            status: 400,
+            body: {
+                error: 'Could not get tracks from any member',
+                skippedMembers: [{ id: 1, displayName: 'Owner needing login', reason: 'token-invalid' }],
+            },
+        });
+    });
+
+    it('reports members with no usable tracks', async () => {
+        const noTracksMember = {
+            ...member,
+            id: 2,
+            spotify_id: 'member-spotify-id',
+            display_name: 'Member without tracks',
+        };
+        mocks.query
+            .mockResolvedValueOnce({ rows: [playlist(null)] })
+            .mockResolvedValueOnce({ rows: [member, noTracksMember] })
+            .mockResolvedValueOnce({ rows: [{ spotify_id: 'owner-spotify-id', access_token: 'owner-access-token' }] })
+            .mockResolvedValue({ rows: [] });
+        mocks.filterTracks
+            .mockReturnValueOnce({ tracks: [track], filteredByDuration: 0, filteredByName: 0 })
+            .mockReturnValueOnce({ tracks: [], filteredByDuration: 0, filteredByName: 0 });
+        mocks.createPlaylist.mockResolvedValue({
+            id: 'new-spotify-playlist',
+            external_urls: { spotify: 'https://open.spotify.com/playlist/new-spotify-playlist' },
+        });
+
+        await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toMatchObject({
+            ok: true,
+            skippedMembers: [{ id: 2, displayName: 'Member without tracks', reason: 'no-tracks' }],
+        });
     });
 
     it('throws a descriptive error when the playlist does not exist', async () => {
@@ -281,6 +354,7 @@ describe('generatePlaylist', () => {
         await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toEqual({
             ok: false,
             reason: 'no-members',
+            skippedMembers: [],
         });
     });
 
@@ -292,6 +366,7 @@ describe('generatePlaylist', () => {
         await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toEqual({
             ok: false,
             reason: 'no-tokens',
+            skippedMembers: [],
         });
     });
 
@@ -304,6 +379,7 @@ describe('generatePlaylist', () => {
         await expect(generatePlaylist(12, { sortMode: 'shuffle' })).resolves.toEqual({
             ok: false,
             reason: 'no-tracks',
+            skippedMembers: [],
         });
     });
 

--- a/packages/backend/src/services/playlist-generation.ts
+++ b/packages/backend/src/services/playlist-generation.ts
@@ -65,9 +65,11 @@ export async function generatePlaylist(
             },
         });
         if (!accessToken) {
-            if (tokenInvalid) {
-                skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'token-invalid' });
-            }
+            skippedMembers.push({
+                id: member.id,
+                displayName: member.display_name,
+                reason: tokenInvalid ? 'token-invalid' : 'no-tracks',
+            });
             continue;
         }
 
@@ -99,6 +101,7 @@ export async function generatePlaylist(
             userTracks.set(member.spotify_id, tracks);
         } catch (error) {
             logger.error({ err: error, memberId: member.id }, 'Failed to get top tracks');
+            skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
         }
     }
 

--- a/packages/backend/src/services/playlist-generation.ts
+++ b/packages/backend/src/services/playlist-generation.ts
@@ -6,9 +6,27 @@ import { decryptSecret } from '../utils/crypto';
 import { logger } from '../utils/logger';
 import { metrics } from '../utils/metrics';
 
+export type SkippedMember = {
+    id: number;
+    displayName: string | null;
+    reason: 'token-invalid' | 'no-tracks';
+};
+
 export type GenerateOutcome =
-    | { ok: true; spotifyPlaylistId: string; spotifyUrl: string; trackCount: number; created: boolean; memberCount: number }
-    | { ok: false; reason: 'no-members' | 'no-tokens' | 'no-tracks' | 'owner-token-unavailable' };
+    | {
+        ok: true;
+        spotifyPlaylistId: string;
+        spotifyUrl: string;
+        trackCount: number;
+        created: boolean;
+        memberCount: number;
+        skippedMembers: SkippedMember[];
+    }
+    | {
+        ok: false;
+        reason: 'no-members' | 'no-tokens' | 'no-tracks' | 'owner-token-unavailable';
+        skippedMembers: SkippedMember[];
+    };
 
 export async function generatePlaylist(
     playlistId: number,
@@ -24,7 +42,7 @@ export async function generatePlaylist(
     const playlist = playlistResult.rows[0];
 
     const membersResult = await pool.query(
-        `SELECT u.id, u.spotify_id, u.access_token, u.refresh_token, u.token_expires_at
+        `SELECT u.id, u.spotify_id, u.display_name, u.access_token, u.refresh_token, u.token_expires_at, u.token_status
        FROM playlist_members pm
        JOIN users u ON pm.user_id = u.id
        WHERE pm.playlist_id = $1
@@ -33,19 +51,25 @@ export async function generatePlaylist(
     );
 
     if (membersResult.rows.length === 0) {
-        return { ok: false, reason: 'no-members' };
+        return { ok: false, reason: 'no-members', skippedMembers: [] };
     }
 
     const userTracks = new Map<string, SpotifyTrack[]>();
+    const skippedMembers: SkippedMember[] = [];
     let ownerAccessToken: string | null = null;
 
     for (const member of membersResult.rows) {
-        const { accessToken } = await getValidAccessToken(member, {
+        const { accessToken, tokenInvalid } = await getValidAccessToken(member, {
             onRefreshError: (error) => {
                 logger.error({ err: error, memberId: member.id }, 'Failed to refresh token');
             },
         });
-        if (!accessToken) continue;
+        if (!accessToken) {
+            if (tokenInvalid) {
+                skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'token-invalid' });
+            }
+            continue;
+        }
 
         if (member.id === playlist.owner_id) {
             ownerAccessToken = accessToken;
@@ -69,6 +93,9 @@ export async function generatePlaylist(
                 filteredByName: filterResult.filteredByName,
                 remaining: tracks.length,
             }, 'Filtered tracks for blend');
+            if (tracks.length === 0) {
+                skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
+            }
             userTracks.set(member.spotify_id, tracks);
         } catch (error) {
             logger.error({ err: error, memberId: member.id }, 'Failed to get top tracks');
@@ -76,13 +103,13 @@ export async function generatePlaylist(
     }
 
     if (userTracks.size === 0) {
-        return { ok: false, reason: 'no-tokens' };
+        return { ok: false, reason: 'no-tokens', skippedMembers };
     }
 
     const { tracks } = await blendTracks(userTracks, { totalTracks: 100, sortMode: options.sortMode });
 
     if (tracks.length === 0) {
-        return { ok: false, reason: 'no-tracks' };
+        return { ok: false, reason: 'no-tracks', skippedMembers };
     }
 
     const ownerResult = await pool.query(
@@ -96,7 +123,7 @@ export async function generatePlaylist(
     }
 
     if (!ownerAccessToken) {
-        return { ok: false, reason: 'owner-token-unavailable' };
+        return { ok: false, reason: 'owner-token-unavailable', skippedMembers };
     }
 
     const created = !playlist.spotify_playlist_id;
@@ -156,5 +183,6 @@ export async function generatePlaylist(
         trackCount: tracks.length,
         created,
         memberCount: membersResult.rows.length,
+        skippedMembers,
     };
 }

--- a/packages/backend/src/services/spotify-token.test.ts
+++ b/packages/backend/src/services/spotify-token.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    query: vi.fn(),
+    refreshToken: vi.fn(),
+    isRefreshTokenPermanentlyInvalid: vi.fn(),
+    loggerWarn: vi.fn(),
+    tokenInvalidated: vi.fn(),
+    usersTokenInvalid: vi.fn(),
+}));
+
+vi.mock('../config/database', () => ({
+    pool: { query: mocks.query },
+}));
+
+vi.mock('./spotify', () => ({
+    spotifyService: { refreshToken: mocks.refreshToken },
+    isRefreshTokenPermanentlyInvalid: mocks.isRefreshTokenPermanentlyInvalid,
+}));
+
+vi.mock('../utils/logger', () => ({
+    logger: { warn: mocks.loggerWarn },
+}));
+
+vi.mock('../utils/metrics', () => ({
+    metrics: {
+        tokenInvalidated: { inc: mocks.tokenInvalidated },
+        usersTokenInvalid: { set: mocks.usersTokenInvalid },
+    },
+}));
+
+import { getValidAccessToken } from './spotify-token';
+
+const expiredUser = {
+    id: 42,
+    access_token: 'old-access-token',
+    refresh_token: 'refresh-token',
+    token_expires_at: new Date(0),
+    token_status: 'active' as const,
+};
+
+describe('getValidAccessToken', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('persists invalid status only for permanently invalid refresh tokens', async () => {
+        const refreshError = new Error('invalid grant');
+        mocks.refreshToken.mockRejectedValue(refreshError);
+        mocks.isRefreshTokenPermanentlyInvalid.mockReturnValue(true);
+        mocks.query
+            .mockResolvedValueOnce({ rows: [{ id: expiredUser.id }] })
+            .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+
+        await expect(getValidAccessToken(expiredUser, { onRefreshError: vi.fn() })).resolves.toMatchObject({
+            accessToken: null,
+            tokenInvalid: true,
+        });
+
+        expect(mocks.query).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("SET token_status = 'invalid'"),
+            [expiredUser.id]
+        );
+        expect(mocks.tokenInvalidated).toHaveBeenCalledOnce();
+        expect(mocks.usersTokenInvalid).toHaveBeenCalledWith(1);
+        expect(mocks.loggerWarn).toHaveBeenCalledWith(
+            { userId: expiredUser.id, reason: 'invalid_grant' },
+            'Refresh token permanently invalid'
+        );
+    });
+
+    it('does not change token status for a temporary refresh failure', async () => {
+        mocks.refreshToken.mockRejectedValue(new Error('timeout'));
+        mocks.isRefreshTokenPermanentlyInvalid.mockReturnValue(false);
+
+        await expect(getValidAccessToken(expiredUser, { onRefreshError: vi.fn() })).resolves.toMatchObject({
+            accessToken: null,
+            tokenInvalid: false,
+        });
+
+        expect(mocks.query).not.toHaveBeenCalled();
+        expect(mocks.tokenInvalidated).not.toHaveBeenCalled();
+    });
+
+    it('restores active status after a successful forced refresh', async () => {
+        mocks.refreshToken.mockResolvedValue({
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 3600,
+        });
+        mocks.query
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+        await expect(getValidAccessToken({ ...expiredUser, token_status: 'invalid' }, { forceRefresh: true })).resolves.toMatchObject({
+            accessToken: 'new-access-token',
+            tokenInvalid: false,
+        });
+
+        expect(mocks.query).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("token_status = 'active'"),
+            expect.arrayContaining(['new-access-token', 'new-refresh-token', expiredUser.id])
+        );
+        expect(mocks.usersTokenInvalid).toHaveBeenCalledWith(0);
+    });
+});

--- a/packages/backend/src/services/spotify-token.ts
+++ b/packages/backend/src/services/spotify-token.ts
@@ -1,50 +1,104 @@
 import { pool } from '../config/database';
 import { decryptSecret, encryptSecret } from '../utils/crypto';
-import { spotifyService } from './spotify';
+import { logger } from '../utils/logger';
+import { metrics } from '../utils/metrics';
+import { isRefreshTokenPermanentlyInvalid, spotifyService } from './spotify';
 
 export interface SpotifyTokenUser {
     id: number;
     access_token: string | null;
     refresh_token: string | null;
     token_expires_at: Date;
+    token_status?: 'active' | 'invalid';
 }
 
 export interface ValidAccessToken {
     accessToken: string | null;
     refreshTokenUnavailable: boolean;
+    tokenInvalid: boolean;
+    expiresAt: Date | null;
 }
 
 interface GetValidAccessTokenOptions {
     onRefreshError?: (error: unknown) => void;
+    forceRefresh?: boolean;
+}
+
+export async function refreshTokenInvalidUsersGauge(): Promise<void> {
+    try {
+        const result = await pool.query("SELECT COUNT(*) AS count FROM users WHERE token_status = 'invalid'");
+        metrics.usersTokenInvalid.set(Number(result.rows[0].count));
+    } catch (error) {
+        logger.warn({ err: error }, 'Failed to update invalid Spotify token gauge');
+    }
+}
+
+async function markRefreshTokenInvalid(userId: number): Promise<void> {
+    const result = await pool.query(
+        `UPDATE users
+         SET token_status = 'invalid', token_invalidated_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1 AND token_status IS DISTINCT FROM 'invalid'
+         RETURNING id`,
+        [userId]
+    );
+
+    if (result.rows.length > 0) {
+        metrics.tokenInvalidated.inc();
+    }
+    logger.warn({ userId, reason: 'invalid_grant' }, 'Refresh token permanently invalid');
+    await refreshTokenInvalidUsersGauge();
 }
 
 export async function getValidAccessToken(
     user: SpotifyTokenUser,
     options: GetValidAccessTokenOptions = {}
 ): Promise<ValidAccessToken> {
-    let accessToken = decryptSecret(user.access_token);
+    if (user.token_status === 'invalid' && !options.forceRefresh) {
+        return {
+            accessToken: null,
+            refreshTokenUnavailable: false,
+            tokenInvalid: true,
+            expiresAt: null,
+        };
+    }
 
-    if (new Date(user.token_expires_at) <= new Date()) {
+    let accessToken = decryptSecret(user.access_token);
+    let expiresAt = new Date(user.token_expires_at);
+
+    if (options.forceRefresh || expiresAt <= new Date()) {
         try {
             const refreshToken = decryptSecret(user.refresh_token);
             if (!refreshToken) {
-                return { accessToken: null, refreshTokenUnavailable: true };
+                return { accessToken: null, refreshTokenUnavailable: true, tokenInvalid: false, expiresAt: null };
             }
 
             const tokens = await spotifyService.refreshToken(refreshToken);
             accessToken = tokens.access_token;
+            expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
             await pool.query(
-                'UPDATE users SET access_token = $1, refresh_token = COALESCE($2, refresh_token), token_expires_at = $3 WHERE id = $4',
-                [encryptSecret(accessToken), encryptSecret(tokens.refresh_token), new Date(Date.now() + tokens.expires_in * 1000), user.id]
+                `UPDATE users SET
+                   access_token = $1,
+                   refresh_token = COALESCE($2, refresh_token),
+                   token_expires_at = $3,
+                   token_status = 'active',
+                   token_invalidated_at = NULL,
+                   updated_at = CURRENT_TIMESTAMP
+                 WHERE id = $4`,
+                [encryptSecret(accessToken), encryptSecret(tokens.refresh_token), expiresAt, user.id]
             );
+            await refreshTokenInvalidUsersGauge();
         } catch (error) {
+            const tokenInvalid = isRefreshTokenPermanentlyInvalid(error);
+            if (tokenInvalid) {
+                await markRefreshTokenInvalid(user.id);
+            }
             if (options.onRefreshError) {
                 options.onRefreshError(error);
-                return { accessToken: null, refreshTokenUnavailable: false };
+                return { accessToken: null, refreshTokenUnavailable: false, tokenInvalid, expiresAt: null };
             }
             throw error;
         }
     }
 
-    return { accessToken, refreshTokenUnavailable: false };
+    return { accessToken, refreshTokenUnavailable: false, tokenInvalid: false, expiresAt };
 }

--- a/packages/backend/src/services/spotify.test.ts
+++ b/packages/backend/src/services/spotify.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect } from 'vitest';
-import { spotifyService } from './spotify';
+import { isRefreshTokenPermanentlyInvalid, spotifyService } from './spotify';
 
 // Mock track for testing
 function createMockTrack(name: string, duration_ms?: number) {
@@ -122,6 +122,35 @@ describe('filterInstrumentalTracks', () => {
 
         const result = spotifyService.filterInstrumentalTracks(tracks);
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('isRefreshTokenPermanentlyInvalid', () => {
+    function axiosError(status: number, data: unknown) {
+        return {
+            isAxiosError: true,
+            response: { status, data },
+        };
+    }
+
+    it('identifies Spotify invalid_grant responses', () => {
+        expect(isRefreshTokenPermanentlyInvalid(axiosError(400, { error: 'invalid_grant' }))).toBe(true);
+    });
+
+    it('does not treat other 400 responses as permanent invalidation', () => {
+        expect(isRefreshTokenPermanentlyInvalid(axiosError(400, { error: 'invalid_request' }))).toBe(false);
+    });
+
+    it('does not treat 500 responses as permanent invalidation', () => {
+        expect(isRefreshTokenPermanentlyInvalid(axiosError(500, { error: 'invalid_grant' }))).toBe(false);
+    });
+
+    it('does not treat timeouts as permanent invalidation', () => {
+        expect(isRefreshTokenPermanentlyInvalid({ isAxiosError: true, code: 'ECONNABORTED' })).toBe(false);
+    });
+
+    it('does not treat response bodies without an error field as permanent invalidation', () => {
+        expect(isRefreshTokenPermanentlyInvalid(axiosError(400, {}))).toBe(false);
     });
 });
 

--- a/packages/backend/src/services/spotify.ts
+++ b/packages/backend/src/services/spotify.ts
@@ -39,6 +39,18 @@ export interface TrackFilterResult {
 
 const DEFAULT_MIN_TRACK_DURATION_MS = 90000;
 
+export function isRefreshTokenPermanentlyInvalid(error: unknown): boolean {
+    if (!axios.isAxiosError(error) || error.response?.status !== 400) {
+        return false;
+    }
+
+    const responseData = error.response.data;
+    return typeof responseData === 'object'
+        && responseData !== null
+        && 'error' in responseData
+        && responseData.error === 'invalid_grant';
+}
+
 export class SpotifyService {
     private clientId: string;
     private clientSecret: string;

--- a/packages/backend/src/utils/metrics.ts
+++ b/packages/backend/src/utils/metrics.ts
@@ -33,6 +33,16 @@ export const metrics = {
         help: 'Number of active users currently registered',
         registers: [registry],
     }),
+    tokenInvalidated: new Counter({
+        name: 'reblend_token_invalidated_total',
+        help: 'Total number of users whose Spotify refresh token was permanently invalidated',
+        registers: [registry],
+    }),
+    usersTokenInvalid: new Gauge({
+        name: 'reblend_users_token_invalid',
+        help: 'Number of users with a permanently invalid Spotify refresh token',
+        registers: [registry],
+    }),
     httpRequests: new Counter({
         name: 'reblend_http_requests_total',
         help: 'Total number of HTTP requests',


### PR DESCRIPTION
Closes #208

メンバーの Spotify 連携が切れていると、そのメンバーの曲は黙ってブレンドから落ちていた。失効を検出して永続化し、API から参照できるようにする。UI 表示は #209 で行う。

## 変更

- `users` に `token_status` / `token_invalidated_at` を追加（既存 DB にも冪等に適用）
- リフレッシュ失敗を**恒久的失敗と一時的失敗で区別**する。axios エラーかつ 400 かつ `error === 'invalid_grant'` のときだけ `invalid` にし、ネットワークエラー / 5xx / 429 では状態を変えない
- 再ログイン（`/api/auth/callback`）と `/api/auth/refresh` の成功で `active` に戻る
- `GET /api/auth/me` と `GET /api/playlists/:id` の members に `tokenStatus` を追加
- `POST /api/playlists/:id/generate` のレスポンスに `skippedMembers` を追加（`token-invalid` / `no-tracks`）
- メトリクス `reblend_token_invalidated_total`、`reblend_users_token_invalid`

## 設計判断

恒久 / 一時を区別しないと、Spotify 側の一時障害で全ユーザーが「連携切れ」表示になり UI が信用されなくなる。判定関数には 400 invalid_grant / 400 その他 / 500 / タイムアウト / body なしのテストを付けている。

トップ曲の取得に失敗したメンバーと、一時的な理由でトークンを取得できなかったメンバーも `no-tracks` として `skippedMembers` に含める（`token_status` は変更しない）。「黙って落ちる」ケースを残さないため。

backend 60 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)