### PR TITLE
feat(backend): broaden instrumental track name patterns

### DIFF
--- a/packages/backend/src/services/spotify.test.ts
+++ b/packages/backend/src/services/spotify.test.ts
@@ -149,7 +149,6 @@ describe('filterInstrumentalTracks', () => {
         ['skit', /\bskit\b/i, 'Skit #1', 'Skittish'],
         ['overture', /\boverture\b/i, 'Overture', 'Overturn'],
         ['Japanese overture', /序曲/i, '序曲', '前奏曲'],
-        ['sound effect', /\bSE\b/, 'Track [SE]', 'Se'],
     ])('filters %s titles without matching its counterexample', (_description, pattern, excludedName, keptName) => {
         expect(INSTRUMENTAL_TRACK_NAME_PATTERNS.some(candidate => (
             candidate.source === pattern.source && candidate.flags === pattern.flags
@@ -184,10 +183,14 @@ describe('filterInstrumentalTracks', () => {
         }, 'Excluded instrumental track by name pattern');
     });
 
-    it('does not match SE when it is part of a longer title word', () => {
-        const result = spotifyService.filterInstrumentalTracks([createMockTrack('SEASON')]);
+    it.each([
+        'SE TE NOTA',
+        'ASI SE BAILA',
+        'NO SE VA',
+    ])('keeps all-caps regular track "%s"', trackName => {
+        const result = spotifyService.filterInstrumentalTracks([createMockTrack(trackName)]);
 
-        expect(result.map(track => track.name)).toEqual(['SEASON']);
+        expect(result.map(track => track.name)).toEqual([trackName]);
     });
 });
 

--- a/packages/backend/src/services/spotify.test.ts
+++ b/packages/backend/src/services/spotify.test.ts
@@ -1,5 +1,20 @@
-import { afterEach, describe, it, expect } from 'vitest';
-import { isRefreshTokenPermanentlyInvalid, spotifyService } from './spotify';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+    INSTRUMENTAL_TRACK_NAME_PATTERNS,
+    isRefreshTokenPermanentlyInvalid,
+    normalizeTrackName,
+    spotifyService,
+} from './spotify';
+
+const mocks = vi.hoisted(() => ({
+    loggerDebug: vi.fn(),
+}));
+
+vi.mock('../utils/logger', () => ({
+    logger: {
+        debug: mocks.loggerDebug,
+    },
+}));
 
 // Mock track for testing
 function createMockTrack(name: string, duration_ms?: number) {
@@ -16,6 +31,8 @@ function createMockTrack(name: string, duration_ms?: number) {
 const originalMinTrackDurationMs = process.env.MIN_TRACK_DURATION_MS;
 
 afterEach(() => {
+    mocks.loggerDebug.mockClear();
+
     if (originalMinTrackDurationMs === undefined) {
         delete process.env.MIN_TRACK_DURATION_MS;
     } else {
@@ -123,6 +140,55 @@ describe('filterInstrumentalTracks', () => {
         const result = spotifyService.filterInstrumentalTracks(tracks);
         expect(result).toHaveLength(0);
     });
+
+    it.each([
+        ['interlude', /\binterlude\b/i, 'Album Interlude', 'Interstellar'],
+        ['Japanese interlude', /インタールード/i, 'インタールード', 'インターナショナル'],
+        ['intro', /\bintro\b/i, 'Intro', 'Introduction'],
+        ['outro', /\boutro\b/i, 'Song (Outro)', 'Outrovert'],
+        ['skit', /\bskit\b/i, 'Skit #1', 'Skittish'],
+        ['overture', /\boverture\b/i, 'Overture', 'Overturn'],
+        ['Japanese overture', /序曲/i, '序曲', '前奏曲'],
+        ['sound effect', /\bSE\b/, 'Track [SE]', 'Se'],
+    ])('filters %s titles without matching its counterexample', (_description, pattern, excludedName, keptName) => {
+        expect(INSTRUMENTAL_TRACK_NAME_PATTERNS.some(candidate => (
+            candidate.source === pattern.source && candidate.flags === pattern.flags
+        ))).toBe(true);
+
+        const result = spotifyService.filterInstrumentalTracks([
+            createMockTrack(excludedName),
+            createMockTrack(keptName),
+        ]);
+
+        expect(result.map(track => track.name)).toEqual([keptName]);
+    });
+
+    it('normalizes full-width punctuation before matching name patterns', () => {
+        expect(normalizeTrackName('曲［Inst］〜')).toBe('曲[Inst]~');
+
+        const result = spotifyService.filterInstrumentalTracks([
+            createMockTrack('曲［Inst］'),
+            createMockTrack('曲（Interlude）'),
+            createMockTrack('Introduction〜'),
+        ]);
+
+        expect(result.map(track => track.name)).toEqual(['Introduction〜']);
+    });
+
+    it('logs each excluded track name at debug level', () => {
+        spotifyService.filterInstrumentalTracks([createMockTrack('Album Interlude')]);
+
+        expect(mocks.loggerDebug).toHaveBeenCalledWith({
+            trackName: 'Album Interlude',
+            pattern: '\\binterlude\\b',
+        }, 'Excluded instrumental track by name pattern');
+    });
+
+    it('does not match SE when it is part of a longer title word', () => {
+        const result = spotifyService.filterInstrumentalTracks([createMockTrack('SEASON')]);
+
+        expect(result.map(track => track.name)).toEqual(['SEASON']);
+    });
 });
 
 describe('isRefreshTokenPermanentlyInvalid', () => {
@@ -167,7 +233,7 @@ describe('filterTracks', () => {
 
     it('filters tracks below the minimum duration', () => {
         const result = spotifyService.filterTracks([
-            createMockTrack('Short interlude', 89999),
+            createMockTrack('Short track', 89999),
             createMockTrack('Full song', 90001),
         ], { minDurationMs: 90000 });
 
@@ -187,7 +253,7 @@ describe('filterTracks', () => {
     it('uses the default duration when the environment variable is unset', () => {
         delete process.env.MIN_TRACK_DURATION_MS;
 
-        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+        const result = spotifyService.filterTracks([createMockTrack('Short track', 89999)]);
 
         expect(result.tracks).toHaveLength(0);
     });
@@ -195,7 +261,7 @@ describe('filterTracks', () => {
     it('uses the default duration when the environment variable is invalid', () => {
         process.env.MIN_TRACK_DURATION_MS = 'not-a-number';
 
-        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+        const result = spotifyService.filterTracks([createMockTrack('Short track', 89999)]);
 
         expect(result.tracks).toHaveLength(0);
     });
@@ -203,7 +269,7 @@ describe('filterTracks', () => {
     it('uses the default duration when the environment variable is empty', () => {
         process.env.MIN_TRACK_DURATION_MS = '';
 
-        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 89999)]);
+        const result = spotifyService.filterTracks([createMockTrack('Short track', 89999)]);
 
         expect(result.tracks).toHaveLength(0);
     });
@@ -211,15 +277,25 @@ describe('filterTracks', () => {
     it('disables duration filtering when the environment variable is zero', () => {
         process.env.MIN_TRACK_DURATION_MS = '0';
 
-        const result = spotifyService.filterTracks([createMockTrack('Short interlude', 1)]);
+        const result = spotifyService.filterTracks([createMockTrack('Short track', 1)]);
 
-        expect(result.tracks.map(track => track.name)).toEqual(['Short interlude']);
+        expect(result.tracks.map(track => track.name)).toEqual(['Short track']);
         expect(result.filteredByDuration).toBe(0);
     });
 
     it('reports tracks matching both filters as name exclusions', () => {
         const result = spotifyService.filterTracks([
             createMockTrack('Short Song (Instrumental)', 1),
+        ], { minDurationMs: 90000 });
+
+        expect(result.tracks).toHaveLength(0);
+        expect(result.filteredByName).toBe(1);
+        expect(result.filteredByDuration).toBe(0);
+    });
+
+    it('counts tracks matching the added name patterns as name exclusions', () => {
+        const result = spotifyService.filterTracks([
+            createMockTrack('Overture', 120000),
         ], { minDurationMs: 90000 });
 
         expect(result.tracks).toHaveLength(0);

--- a/packages/backend/src/services/spotify.ts
+++ b/packages/backend/src/services/spotify.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { logger } from '../utils/logger';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 const SPOTIFY_AUTH_BASE = 'https://accounts.spotify.com';
@@ -49,6 +50,34 @@ export function isRefreshTokenPermanentlyInvalid(error: unknown): boolean {
         && responseData !== null
         && 'error' in responseData
         && responseData.error === 'invalid_grant';
+}
+
+export const INSTRUMENTAL_TRACK_NAME_PATTERNS: readonly RegExp[] = [
+    /\binstrumental\b/i,
+    /インストゥルメンタル/i,
+    /インスト/i,
+    /\bkaraoke\b/i,
+    /カラオケ/i,
+    /\boff vocal\b/i,
+    /オフボーカル/i,
+    /\b-?inst\.?\b/i,
+    /\(inst\.?\)/i,
+    /\[inst\.?\]/i,
+    /\bno vocals?\b/i,
+    /\bwithout vocals?\b/i,
+    /\bbacking track\b/i,
+    /\binterlude\b/i,
+    /インタールード/i,
+    /\bintro\b/i,
+    /\boutro\b/i,
+    /\bskit\b/i,
+    /\boverture\b/i,
+    /序曲/i,
+    /\bSE\b/,
+];
+
+export function normalizeTrackName(name: string): string {
+    return name.normalize('NFKC').replace(/[〜～]/g, '~');
 }
 
 export class SpotifyService {
@@ -144,32 +173,15 @@ export class SpotifyService {
      * so we use name-based heuristics instead.
      */
     filterInstrumentalTracks(tracks: SpotifyTrack[]): SpotifyTrack[] {
-        // Common patterns that indicate instrumental versions
-        const instrumentalPatterns = [
-            /\binstrumental\b/i,
-            /インストゥルメンタル/i,
-            /インスト/i,
-            /\bkaraoke\b/i,
-            /カラオケ/i,
-            /\boff vocal\b/i,
-            /オフボーカル/i,
-            /\b-?inst\.?\b/i,
-            /\(inst\.?\)/i,
-            /\[inst\.?\]/i,
-            /\bno vocals?\b/i,
-            /\bwithout vocals?\b/i,
-            /\bbacking track\b/i,
-        ];
-
         return tracks.filter(track => {
-            const name = track.name.toLowerCase();
-            // Check if any pattern matches
-            for (const pattern of instrumentalPatterns) {
+            const name = normalizeTrackName(track.name);
+            for (const pattern of INSTRUMENTAL_TRACK_NAME_PATTERNS) {
                 if (pattern.test(name)) {
-                    return false; // Exclude this track
+                    logger.debug({ trackName: track.name, pattern: pattern.source }, 'Excluded instrumental track by name pattern');
+                    return false;
                 }
             }
-            return true; // Include this track
+            return true;
         });
     }
 

--- a/packages/backend/src/services/spotify.ts
+++ b/packages/backend/src/services/spotify.ts
@@ -73,7 +73,6 @@ export const INSTRUMENTAL_TRACK_NAME_PATTERNS: readonly RegExp[] = [
     /\bskit\b/i,
     /\boverture\b/i,
     /序曲/i,
-    /\bSE\b/,
 ];
 
 export function normalizeTrackName(name: string): string {


### PR DESCRIPTION
Closes #200

曲名によるインスト判定を強化し、アルバム収録のインタールードや繋ぎトラックを落とす。尺による除外は #199 で実装済み。

## 変更

- パターンを追加: `interlude` / `インタールード` / `intro` / `outro` / `skit` / `overture` / `序曲`
- いずれも単語境界を厳密にし、`Introduction` / `Interstellar` / `Skittish` / `Overturn` などに誤爆しない
- 曲名を NFKC 正規化してから照合（全角括弧・全角英数・波ダッシュの揺れを吸収）
- パターン定義をモジュール定数へ切り出し、テストから参照できるようにした
- 除外した曲名を debug レベルでログ出力（本番データを見てパターンを調整できるように）
- 判定対象は曲名のみ。アルバム名は対象にしない（"Instrumental Works" のようなアルバムで全曲落ちるため）

## 見送ったパターン

`SE` は採用していない。大文字限定にしても、曲名が全て大文字で表記される楽曲（`SE TE NOTA`、`ASI SE BAILA` など）が一致して正規曲を落とす。誤爆のほうがユーザー影響が大きいという Issue の判断基準に従い、取りこぼしは尺フィルタ側に任せる。反例はテストで担保している。

backend 73 tests passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)