### PR TITLE
feat(frontend): surface members with revoked spotify access

### DIFF
--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -1,12 +1,5 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { authApi } from '../services/api';
-
-interface User {
-    id: number;
-    spotifyId: string;
-    displayName: string;
-    email: string;
-}
+import { authApi, User } from '../services/api';
 
 interface AuthContextType {
     user: User | null;
@@ -51,7 +44,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const handleCallback = async (code: string, state: string) => {
         try {
             const response = await authApi.callback(code, state);
-            setUser(response.data.user);
+            setUser({ ...response.data.user, tokenStatus: 'active' });
         } catch (error) {
             console.error('Callback error:', error);
             throw error;

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -303,6 +303,11 @@ button {
   color: var(--color-text-secondary);
 }
 
+.badge-warning {
+  background: rgba(245, 155, 35, 0.2);
+  color: var(--color-warning);
+}
+
 /* Loading spinner */
 .spinner {
   width: 40px;

--- a/packages/frontend/src/pages/DashboardPage.css
+++ b/packages/frontend/src/pages/DashboardPage.css
@@ -58,6 +58,18 @@
     padding: var(--spacing-2xl) 0;
 }
 
+.spotify-connection-warning {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-xl);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-color: var(--color-warning);
+    background: rgba(245, 155, 35, 0.1);
+    color: var(--color-text-primary);
+}
+
 .dashboard-section {
     margin-bottom: var(--spacing-2xl);
 }
@@ -213,5 +225,10 @@
 
     .playlist-grid {
         grid-template-columns: 1fr;
+    }
+
+    .spotify-connection-warning {
+        align-items: stretch;
+        flex-direction: column;
     }
 }

--- a/packages/frontend/src/pages/DashboardPage.test.tsx
+++ b/packages/frontend/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DashboardPage from './DashboardPage';
+
+const apiMocks = vi.hoisted(() => ({
+    list: vi.fn(),
+    invitations: vi.fn(),
+    login: vi.fn(),
+    user: {
+        id: 1,
+        spotifyId: 'owner',
+        displayName: 'オーナー',
+        email: 'owner@example.com',
+        tokenStatus: 'invalid' as const,
+    },
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+    useAuth: () => ({ user: apiMocks.user, login: apiMocks.login, logout: vi.fn() }),
+}));
+
+vi.mock('../services/api', async () => {
+    const actual = await vi.importActual<typeof import('../services/api')>('../services/api');
+    return {
+        ...actual,
+        playlistApi: { ...actual.playlistApi, list: apiMocks.list },
+        invitationApi: { ...actual.invitationApi, list: apiMocks.invitations },
+    };
+});
+
+describe('DashboardPage Spotify connection warning', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        apiMocks.list.mockResolvedValue({ data: [] });
+        apiMocks.invitations.mockResolvedValue({ data: [] });
+    });
+
+    it('shows a re-login warning when the current user has an invalid Spotify connection', async () => {
+        render(
+            <MemoryRouter>
+                <DashboardPage />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Spotifyとの連携が切れています。再ログインしてください');
+        fireEvent.click(screen.getByRole('button', { name: 'Spotifyで再ログイン' }));
+        expect(apiMocks.login).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/frontend/src/pages/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { playlistApi, invitationApi, Playlist, Invitation } from '../services/ap
 import './DashboardPage.css';
 
 export default function DashboardPage() {
-    const { user, logout } = useAuth();
+    const { user, logout, login } = useAuth();
     const [playlists, setPlaylists] = useState<Playlist[]>([]);
     const [invitations, setInvitations] = useState<Invitation[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -85,6 +85,15 @@ export default function DashboardPage() {
 
             <main className="dashboard-main">
                 <div className="container">
+                    {user?.tokenStatus === 'invalid' && (
+                        <div className="spotify-connection-warning card" role="alert">
+                            <p>Spotifyとの連携が切れています。再ログインしてください</p>
+                            <button className="btn btn-primary btn-sm" onClick={() => void login()}>
+                                Spotifyで再ログイン
+                            </button>
+                        </div>
+                    )}
+
                     {/* Pending Invitations */}
                     {invitations.length > 0 && (
                         <section className="dashboard-section animate-slideUp">

--- a/packages/frontend/src/pages/PlaylistDetailPage.css
+++ b/packages/frontend/src/pages/PlaylistDetailPage.css
@@ -23,6 +23,18 @@
     margin-bottom: var(--spacing-xl);
 }
 
+.spotify-connection-warning {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-xl);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-color: var(--color-warning);
+    background: rgba(245, 155, 35, 0.1);
+    color: var(--color-text-primary);
+}
+
 .back-link {
     display: inline-flex;
     align-items: center;
@@ -221,6 +233,13 @@
 .generate-hint {
     margin-top: var(--spacing-md);
     font-size: var(--font-size-sm);
+}
+
+.generate-warning,
+.generate-skipped-members {
+    color: var(--color-warning);
+    font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing-lg);
 }
 
 /* Auto update section */
@@ -492,6 +511,11 @@
     }
 
     .sort-mode-options {
+        flex-direction: column;
+    }
+
+    .spotify-connection-warning {
+        align-items: stretch;
         flex-direction: column;
     }
 }

--- a/packages/frontend/src/pages/PlaylistDetailPage.test.tsx
+++ b/packages/frontend/src/pages/PlaylistDetailPage.test.tsx
@@ -1,17 +1,26 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { PlaylistDetail } from '../services/api';
+import type { PlaylistDetail, User } from '../services/api';
 import PlaylistDetailPage from './PlaylistDetailPage';
 
 const apiMocks = vi.hoisted(() => ({
     get: vi.fn(),
     getTracks: vi.fn(),
+    generate: vi.fn(),
     setAutoUpdate: vi.fn(),
+    login: vi.fn(),
+    user: {
+        id: 1,
+        spotifyId: 'owner',
+        displayName: 'オーナー',
+        email: 'owner@example.com',
+        tokenStatus: 'active',
+    } as User,
 }));
 
 vi.mock('../contexts/AuthContext', () => ({
-    useAuth: () => ({ user: { id: 1 } }),
+    useAuth: () => ({ user: apiMocks.user, login: apiMocks.login }),
 }));
 
 vi.mock('../services/api', async () => {
@@ -22,6 +31,7 @@ vi.mock('../services/api', async () => {
             ...actual.playlistApi,
             get: apiMocks.get,
             getTracks: apiMocks.getTracks,
+            generate: apiMocks.generate,
             setAutoUpdate: apiMocks.setAutoUpdate,
         },
     };
@@ -43,7 +53,7 @@ function createPlaylist(overrides: Partial<PlaylistDetail> = {}): PlaylistDetail
         role: 'owner',
         userRole: 'owner',
         createdAt: '2026-08-15T00:00:00.000Z',
-        members: [{ id: 1, spotifyId: 'owner', displayName: 'オーナー', role: 'owner' }],
+        members: [{ id: 1, spotifyId: 'owner', displayName: 'オーナー', role: 'owner', tokenStatus: 'active' }],
         pendingInvitations: [],
         ...overrides,
     };
@@ -59,9 +69,16 @@ function renderPage() {
     );
 }
 
-describe('PlaylistDetailPage auto update settings', () => {
+describe('PlaylistDetailPage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        apiMocks.user = {
+            id: 1,
+            spotifyId: 'owner',
+            displayName: 'オーナー',
+            email: 'owner@example.com',
+            tokenStatus: 'active',
+        };
         apiMocks.getTracks.mockResolvedValue({ data: { tracks: [] } });
     });
 
@@ -108,5 +125,84 @@ describe('PlaylistDetailPage auto update settings', () => {
 
         expect(await screen.findByRole('switch', { name: '毎日自動で再生成する' })).toBeDisabled();
         expect(screen.getByText('まず一度生成してください')).toBeInTheDocument();
+    });
+
+    it('shows a re-login warning when the current user has an invalid Spotify connection', async () => {
+        apiMocks.user = { ...apiMocks.user, tokenStatus: 'invalid' };
+        apiMocks.get.mockResolvedValue({
+            data: createPlaylist({
+                members: [{ id: 1, spotifyId: 'owner', displayName: 'オーナー', role: 'owner', tokenStatus: 'invalid' }],
+            }),
+        });
+
+        renderPage();
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Spotifyとの連携が切れています。再ログインしてください');
+        fireEvent.click(screen.getByRole('button', { name: 'Spotifyで再ログイン' }));
+        expect(apiMocks.login).toHaveBeenCalledOnce();
+    });
+
+    it('warns about another member with an invalid Spotify connection before generation', async () => {
+        apiMocks.get.mockResolvedValue({
+            data: createPlaylist({
+                members: [
+                    { id: 1, spotifyId: 'owner', displayName: 'オーナー', role: 'owner', tokenStatus: 'active' },
+                    { id: 2, spotifyId: 'member', displayName: 'メンバー', role: 'member', tokenStatus: 'invalid' },
+                ],
+            }),
+        });
+
+        renderPage();
+
+        expect(await screen.findByText('⚠️ 連携切れ')).toBeInTheDocument();
+        expect(screen.getByText(/メンバーさんのSpotify連携が切れているため、曲は含まれません/)).toBeInTheDocument();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('does not show connection warnings when every member is active', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist() });
+
+        renderPage();
+
+        await screen.findByText('週末のブレンド');
+        expect(screen.queryByText('⚠️ 連携切れ')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Spotifyとの連携が切れています/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/曲は含まれません/)).not.toBeInTheDocument();
+    });
+
+    it('shows members whose tracks could not be fetched after generation', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist() });
+        apiMocks.generate.mockResolvedValue({
+            data: {
+                message: 'Playlist generated successfully',
+                spotifyPlaylistId: 'playlist-id',
+                spotifyUrl: 'https://open.spotify.com/playlist/playlist-id',
+                trackCount: 10,
+                skippedMembers: [{ id: 2, displayName: 'メンバー', reason: 'token-invalid' }],
+            },
+        });
+
+        renderPage();
+
+        fireEvent.click(await screen.findByRole('button', { name: 'プレイリストを再生成' }));
+        expect(await screen.findByText('メンバーさんの曲は取得できませんでした')).toBeInTheDocument();
+    });
+
+    it('shows a partial auto update status', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist({ lastAutoUpdateStatus: 'partial' }) });
+
+        renderPage();
+
+        expect(await screen.findByText('一部メンバーの曲を取得できませんでした')).toBeInTheDocument();
+    });
+
+    it('ignores unknown auto update statuses', async () => {
+        apiMocks.get.mockResolvedValue({ data: createPlaylist({ lastAutoUpdateStatus: 'unknown-status' }) });
+
+        renderPage();
+
+        await screen.findByText('週末のブレンド');
+        expect(screen.queryByText('一部メンバーの曲を取得できませんでした')).not.toBeInTheDocument();
+        expect(screen.queryByText('直近の自動更新に失敗しました')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/packages/frontend/src/pages/PlaylistDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { playlistApi, authApi, invitationApi, PlaylistDetail, PlaylistTrack, SortMode } from '../services/api';
+import { playlistApi, authApi, invitationApi, PlaylistDetail, PlaylistTrack, SkippedMember, SortMode } from '../services/api';
 import './PlaylistDetailPage.css';
 
 interface SearchUser {
@@ -14,7 +14,7 @@ interface SearchUser {
 export default function PlaylistDetailPage() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
-    const { user } = useAuth();
+    const { user, login } = useAuth();
     const [playlist, setPlaylist] = useState<PlaylistDetail | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -35,6 +35,7 @@ export default function PlaylistDetailPage() {
         spotifyUrl: string;
         trackCount: number;
         message: string;
+        skippedMembers: SkippedMember[];
     } | null>(null);
     const [sortMode, setSortMode] = useState<SortMode>('shuffle');
 
@@ -136,6 +137,7 @@ export default function PlaylistDetailPage() {
                 spotifyUrl: response.data.spotifyUrl,
                 trackCount: response.data.trackCount,
                 message: response.data.message,
+                skippedMembers: response.data.skippedMembers,
             });
             await loadPlaylist();
             await loadTracks();
@@ -217,11 +219,23 @@ export default function PlaylistDetailPage() {
     const isOwner = playlist.userRole === 'owner';
     const canGenerate = isOwner && playlist.members.length >= 1;
     const isRegenerate = playlist.status === 'generated';
+    const invalidOtherMembers = playlist.members.filter(member =>
+        member.tokenStatus === 'invalid' && member.id !== user?.id
+    );
 
     return (
         <div className="playlist-detail-page">
             <div className="container">
                 <div className="detail-content animate-slideUp">
+                    {user?.tokenStatus === 'invalid' && (
+                        <div className="spotify-connection-warning card" role="alert">
+                            <p>Spotifyとの連携が切れています。再ログインしてください</p>
+                            <button className="btn btn-primary btn-sm" onClick={() => void login()}>
+                                Spotifyで再ログイン
+                            </button>
+                        </div>
+                    )}
+
                     <div className="page-header">
                         <Link to="/dashboard" className="back-link">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -254,6 +268,11 @@ export default function PlaylistDetailPage() {
                             <div className="success-icon">🎉</div>
                             <h2>{generateResult.message}</h2>
                             <p>{generateResult.trackCount}曲がブレンドされました</p>
+                            {generateResult.skippedMembers.length > 0 && (
+                                <p className="generate-skipped-members">
+                                    {generateResult.skippedMembers.map(member => member.displayName ?? '不明なメンバー').join('、')}さんの曲は取得できませんでした
+                                </p>
+                            )}
                             <a
                                 href={generateResult.spotifyUrl}
                                 target="_blank"
@@ -324,6 +343,9 @@ export default function PlaylistDetailPage() {
                                         <span className={`badge badge-${member.role}`}>
                                             {member.role === 'owner' ? 'オーナー' : 'メンバー'}
                                         </span>
+                                        {member.tokenStatus === 'invalid' && (
+                                            <span className="badge badge-warning">⚠️ 連携切れ</span>
+                                        )}
                                     </div>
                                 </div>
                             ))}
@@ -411,6 +433,12 @@ export default function PlaylistDetailPage() {
                                     <br />
                                     <small>※ インストゥルメンタル曲は自動的に除外されます</small>
                                 </p>
+
+                                {invalidOtherMembers.length > 0 && (
+                                    <p className="generate-warning">
+                                        {invalidOtherMembers.map(member => member.displayName).join('、')}さんのSpotify連携が切れているため、曲は含まれません。本人に再ログインを依頼してください。
+                                    </p>
+                                )}
 
                                 <div className="sort-mode-selector">
                                     <label className="sort-mode-label">曲の並び順:</label>
@@ -558,6 +586,9 @@ export default function PlaylistDetailPage() {
                             )}
                             {playlist.lastAutoUpdateStatus === 'failed' && (
                                 <p className="auto-update-warning">直近の自動更新に失敗しました</p>
+                            )}
+                            {playlist.lastAutoUpdateStatus === 'partial' && (
+                                <p className="auto-update-warning">一部メンバーの曲を取得できませんでした</p>
                             )}
                         </div>
                     </section>

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -11,13 +11,31 @@ const api = axios.create({
     },
 });
 
+export type TokenStatus = 'active' | 'invalid';
+
+export interface User {
+    id: number;
+    spotifyId: string;
+    displayName: string;
+    email: string;
+    tokenStatus: TokenStatus;
+}
+
+export type AuthCallbackUser = Omit<User, 'tokenStatus'>;
+
+export interface SkippedMember {
+    id: number;
+    displayName: string | null;
+    reason: 'token-invalid' | 'no-tracks';
+}
+
 // Auth API
 export const authApi = {
     getLoginUrl: () => api.get<{ url: string }>('/api/auth/login'),
 
     callback: (code: string, state: string) =>
         api.post<{
-            user: { id: number; spotifyId: string; displayName: string; email: string };
+            user: AuthCallbackUser;
             expiresAt: string;
         }>('/api/auth/callback', { code, state }),
 
@@ -25,7 +43,7 @@ export const authApi = {
         api.post<{ expiresAt: string }>('/api/auth/refresh'),
 
     getMe: () =>
-        api.get<{ id: number; spotifyId: string; displayName: string; email: string }>('/api/auth/me'),
+        api.get<User>('/api/auth/me'),
 
     logout: () => api.post<{ message: string }>('/api/auth/logout'),
 
@@ -59,6 +77,7 @@ export interface PlaylistDetail extends Playlist {
         spotifyId: string;
         displayName: string;
         role: 'owner' | 'member';
+        tokenStatus: TokenStatus;
     }>;
     pendingInvitations: Array<{
         id: number;
@@ -94,6 +113,7 @@ export const playlistApi = {
             spotifyPlaylistId: string;
             spotifyUrl: string;
             trackCount: number;
+            skippedMembers: SkippedMember[];
         }>(`/api/playlists/${id}/generate`, { sortMode }),
 
     setAutoUpdate: (id: number, settings: { enabled: boolean; sortMode?: SortMode }) =>


### PR DESCRIPTION
Closes #209

Spotify 連携が切れたメンバーの曲は黙ってブレンドから落ちる。誰の連携が切れているか、自分が切れているなら何をすればいいかを UI で分かるようにする。検出と API は #208 で実装済み。

## 変更（導線の強さを意図的に分けている）

**自分の連携が切れている場合**（本人しか直せないので一番強く）
- ダッシュボードと詳細画面の上部に警告バナー + 「Spotifyで再ログイン」ボタン
- バナーは閉じられない（閉じられると気づかないまま放置されるため）

**他のメンバーの場合**（オーナーが直す手段はない）
- メンバー一覧に「⚠️ 連携切れ」バッジ
- 生成カードに事前の注意書き。「本人に再ログインを依頼してください」に留め、通知機能は範囲外

**生成結果**
- `skippedMembers` があれば「◯◯さんの曲は取得できませんでした」を表示

**自動更新の状態**
- `lastAutoUpdateStatus === 'partial'` を「一部メンバーの曲を取得できませんでした」として表示（#203 で記録される）。未知の値は引き続き無視する

## テスト

frontend 11 tests passed。自分が invalid / 他人が invalid / 全員 active（追加 UI が一切出ないこと）/ 生成後のスキップ表示 / partial / 未知ステータスの無視。

🤖 Generated with [Claude Code](https://claude.com/claude-code)