### PR TITLE
feat(backend): instrument playlist generation with custom spans

### DIFF
--- a/packages/backend/src/services/auto-update-scheduler.test.ts
+++ b/packages/backend/src/services/auto-update-scheduler.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NodeSDK, tracing } from '@opentelemetry/sdk-node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
     connect: vi.fn(),
@@ -54,6 +55,9 @@ vi.mock('node-cron', () => ({
 
 import { getAutoUpdateConfig, runAutoUpdateJob, startAutoUpdateScheduler } from './auto-update-scheduler';
 
+const exporter = new tracing.InMemorySpanExporter();
+let telemetry: NodeSDK;
+
 const enabledConfig = {
     enabled: true,
     cronExpression: '0 5 * * *',
@@ -74,9 +78,27 @@ function successfulOutcome(skippedMembers: unknown[] = []) {
 }
 
 describe('automatic update scheduler', () => {
+    beforeAll(() => {
+        vi.stubEnv('OTEL_SDK_DISABLED', 'false');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
+        telemetry = new NodeSDK({
+            instrumentations: [],
+            spanProcessors: [new tracing.SimpleSpanProcessor(exporter)],
+        });
+        telemetry.start();
+    });
+
+    afterAll(async () => {
+        await telemetry.shutdown();
+        vi.unstubAllEnvs();
+    });
+
     beforeEach(() => {
+        exporter.reset();
         vi.clearAllMocks();
         vi.stubEnv('AUTO_UPDATE_ENABLED', 'false');
+        vi.stubEnv('OTEL_SDK_DISABLED', 'false');
+        vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
         mocks.cronValidate.mockReturnValue(true);
         mocks.connect.mockResolvedValue({ query: mocks.lockQuery, release: mocks.release });
         mocks.poolQuery.mockResolvedValue({ rows: [] });
@@ -187,5 +209,23 @@ describe('automatic update scheduler', () => {
         expect(mocks.lockQuery).toHaveBeenCalledTimes(1);
         expect(mocks.autoUpdateRuns).toHaveBeenCalledWith({ result: 'skipped' });
         expect(mocks.release).toHaveBeenCalledOnce();
+    });
+
+    it('records each scheduled playlist below an independent job root span', async () => {
+        mocks.lockQuery
+            .mockResolvedValueOnce({ rows: [{ locked: true }] })
+            .mockResolvedValueOnce({ rows: [{ id: 1, auto_update_sort_mode: 'shuffle' }] });
+        mocks.generatePlaylist.mockResolvedValueOnce(successfulOutcome());
+
+        await runAutoUpdateJob(enabledConfig);
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const spans = exporter.getFinishedSpans();
+        const runSpan = spans.find(span => span.name === 'auto_update.run');
+        const playlistSpan = spans.find(span => span.name === 'auto_update.playlist');
+        expect(runSpan?.parentSpanContext).toBeUndefined();
+        expect(runSpan?.attributes).toMatchObject({ 'job.playlist_count': 1 });
+        expect(playlistSpan?.attributes).toMatchObject({ 'playlist.id': 1 });
+        expect(playlistSpan?.parentSpanContext?.spanId).toBe(runSpan?.spanContext().spanId);
     });
 });

--- a/packages/backend/src/services/auto-update-scheduler.ts
+++ b/packages/backend/src/services/auto-update-scheduler.ts
@@ -5,6 +5,7 @@ import { SortMode } from './blend';
 import { generatePlaylist } from './playlist-generation';
 import { logger } from '../utils/logger';
 import { metrics } from '../utils/metrics';
+import { recordSpanError, withSpan } from '../utils/tracing';
 
 const DEFAULT_CRON = '0 5 * * *';
 const DEFAULT_TIMEZONE = 'Asia/Tokyo';
@@ -98,53 +99,58 @@ async function recordResult(
 }
 
 async function updatePlaylist(jobId: string, playlist: AutoUpdatePlaylist): Promise<void> {
-    const startedAt = Date.now();
-    let trackCount = 0;
+    return withSpan('auto_update.playlist', { 'playlist.id': playlist.id }, async () => {
+        const startedAt = Date.now();
+        let trackCount = 0;
 
-    try {
-        const outcome = await generatePlaylist(playlist.id, { sortMode: sortModeFor(playlist) });
-        if (!outcome.ok) {
-            await recordResult(playlist.id, 'failed', `Generation could not complete: ${outcome.reason}`);
-            metrics.autoUpdateRuns.inc({ result: 'failed' });
-            logger.warn({ jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update failed');
-            return;
-        }
-
-        trackCount = outcome.trackCount;
-        const status = outcome.skippedMembers.length > 0 ? 'partial' : 'success';
-        const error = status === 'partial' ? `Skipped ${outcome.skippedMembers.length} member(s)` : null;
-        await recordResult(playlist.id, status, error);
-        metrics.autoUpdateRuns.inc({ result: status });
-        if (status === 'success') {
-            metrics.autoUpdateLastSuccessTimestamp.set(Date.now() / 1000);
-        }
-        logger.info({ jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update completed');
-    } catch (error) {
         try {
-            await recordResult(playlist.id, 'failed', 'Automatic update failed');
-        } catch (recordError) {
-            logger.error({ err: recordError, jobId, playlistId: playlist.id }, 'Failed to record automatic update result');
+            const outcome = await generatePlaylist(playlist.id, { sortMode: sortModeFor(playlist) });
+            if (!outcome.ok) {
+                await recordResult(playlist.id, 'failed', `Generation could not complete: ${outcome.reason}`);
+                metrics.autoUpdateRuns.inc({ result: 'failed' });
+                logger.warn({ jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update failed');
+                return;
+            }
+
+            trackCount = outcome.trackCount;
+            const status = outcome.skippedMembers.length > 0 ? 'partial' : 'success';
+            const error = status === 'partial' ? `Skipped ${outcome.skippedMembers.length} member(s)` : null;
+            await recordResult(playlist.id, status, error);
+            metrics.autoUpdateRuns.inc({ result: status });
+            if (status === 'success') {
+                metrics.autoUpdateLastSuccessTimestamp.set(Date.now() / 1000);
+            }
+            logger.info({ jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update completed');
+        } catch (error) {
+            recordSpanError(error);
+            try {
+                await recordResult(playlist.id, 'failed', 'Automatic update failed');
+            } catch (recordError) {
+                recordSpanError(recordError);
+                logger.error({ err: recordError, jobId, playlistId: playlist.id }, 'Failed to record automatic update result');
+            }
+            metrics.autoUpdateRuns.inc({ result: 'failed' });
+            logger.error({ err: error, jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update failed');
+        } finally {
+            metrics.autoUpdateDuration.observe((Date.now() - startedAt) / 1000);
         }
-        metrics.autoUpdateRuns.inc({ result: 'failed' });
-        logger.error({ err: error, jobId, playlistId: playlist.id, trackCount, durationMs: Date.now() - startedAt }, 'Automatic playlist update failed');
-    } finally {
-        metrics.autoUpdateDuration.observe((Date.now() - startedAt) / 1000);
-    }
+    });
 }
 
 export async function runAutoUpdateJob(config: AutoUpdateConfig = getAutoUpdateConfig()): Promise<void> {
-    const jobId = randomUUID();
-    const lockClient = await pool.connect();
-    let lockAcquired = false;
+    return withSpan('auto_update.run', { 'job.playlist_count': 0 }, async span => {
+        const jobId = randomUUID();
+        const lockClient = await pool.connect();
+        let lockAcquired = false;
 
-    try {
-        const lockResult = await lockClient.query('SELECT pg_try_advisory_lock($1) AS locked', [AUTO_UPDATE_LOCK_KEY]);
-        lockAcquired = lockResult.rows[0]?.locked === true;
-        if (!lockAcquired) {
-            metrics.autoUpdateRuns.inc({ result: 'skipped' });
-            logger.debug({ jobId }, 'Automatic update job skipped because another instance holds the lock');
-            return;
-        }
+        try {
+            const lockResult = await lockClient.query('SELECT pg_try_advisory_lock($1) AS locked', [AUTO_UPDATE_LOCK_KEY]);
+            lockAcquired = lockResult.rows[0]?.locked === true;
+            if (!lockAcquired) {
+                metrics.autoUpdateRuns.inc({ result: 'skipped' });
+                logger.debug({ jobId }, 'Automatic update job skipped because another instance holds the lock');
+                return;
+            }
 
         const playlistsResult = await lockClient.query<AutoUpdatePlaylist>(
             `SELECT id, auto_update_sort_mode
@@ -153,36 +159,39 @@ export async function runAutoUpdateJob(config: AutoUpdateConfig = getAutoUpdateC
                AND spotify_playlist_id IS NOT NULL
              ORDER BY id ASC`
         );
-        const playlists = playlistsResult.rows;
-        if (playlists.length === 0) {
-            metrics.autoUpdateRuns.inc({ result: 'skipped' });
-            logger.info({ jobId }, 'No playlists are eligible for automatic update');
-            return;
-        }
+            const playlists = playlistsResult.rows;
+            span?.setAttribute('job.playlist_count', playlists.length);
+            if (playlists.length === 0) {
+                metrics.autoUpdateRuns.inc({ result: 'skipped' });
+                logger.info({ jobId }, 'No playlists are eligible for automatic update');
+                return;
+            }
 
-        let nextIndex = 0;
-        const worker = async () => {
-            let hasProcessedPlaylist = false;
-            while (nextIndex < playlists.length) {
-                const playlist = playlists[nextIndex++];
-                if (hasProcessedPlaylist) {
-                    await sleep(PLAYLIST_DELAY_MS);
+            let nextIndex = 0;
+            const worker = async () => {
+                let hasProcessedPlaylist = false;
+                while (nextIndex < playlists.length) {
+                    const playlist = playlists[nextIndex++];
+                    if (hasProcessedPlaylist) {
+                        await sleep(PLAYLIST_DELAY_MS);
+                    }
+                    hasProcessedPlaylist = true;
+                    await updatePlaylist(jobId, playlist);
                 }
-                hasProcessedPlaylist = true;
-                await updatePlaylist(jobId, playlist);
+            };
+            await Promise.all(Array.from({ length: Math.min(config.concurrency, playlists.length) }, worker));
+        } finally {
+            if (lockAcquired) {
+                try {
+                    await lockClient.query('SELECT pg_advisory_unlock($1)', [AUTO_UPDATE_LOCK_KEY]);
+                } catch (error) {
+                    recordSpanError(error);
+                    logger.error({ err: error, jobId }, 'Failed to release automatic update advisory lock');
+                }
             }
-        };
-        await Promise.all(Array.from({ length: Math.min(config.concurrency, playlists.length) }, worker));
-    } finally {
-        if (lockAcquired) {
-            try {
-                await lockClient.query('SELECT pg_advisory_unlock($1)', [AUTO_UPDATE_LOCK_KEY]);
-            } catch (error) {
-                logger.error({ err: error, jobId }, 'Failed to release automatic update advisory lock');
-            }
+            lockClient.release();
         }
-        lockClient.release();
-    }
+    });
 }
 
 export function startAutoUpdateScheduler(): ScheduledTask | undefined {

--- a/packages/backend/src/services/blend.ts
+++ b/packages/backend/src/services/blend.ts
@@ -1,6 +1,7 @@
 import { SpotifyTrack } from './spotify';
 import { reccoBeatsService, smartSortTracks, AudioFeatures } from './reccobeats';
 import { logger } from '../utils/logger';
+import { withSpan } from '../utils/tracing';
 
 export type SortMode = 'shuffle' | 'smart';
 
@@ -53,9 +54,14 @@ export async function blendTracks(
 ): Promise<BlendResult> {
     const { totalTracks = 100, sortMode = 'shuffle' } = options;
     const userCount = userTracks.size;
-    if (userCount === 0) {
-        return { tracks: [], contributionsByUser: new Map() };
-    }
+    return withSpan('blend.tracks', {
+        'blend.user_count': userCount,
+        'blend.sort_mode': sortMode,
+        'blend.total_tracks': totalTracks,
+    }, async () => {
+        if (userCount === 0) {
+            return { tracks: [], contributionsByUser: new Map() };
+        }
 
     // Calculate tracks per user (distribute evenly)
     const tracksPerUser = Math.floor(totalTracks / userCount);
@@ -142,8 +148,9 @@ export async function blendTracks(
         }
     }
 
-    return {
-        tracks: finalTracks,
-        contributionsByUser,
-    };
+        return {
+            tracks: finalTracks,
+            contributionsByUser,
+        };
+    });
 }

--- a/packages/backend/src/services/playlist-generation.tracing.test.ts
+++ b/packages/backend/src/services/playlist-generation.tracing.test.ts
@@ -1,0 +1,202 @@
+import { NodeSDK, tracing } from '@opentelemetry/sdk-node';
+import axios from 'axios';
+import express, { NextFunction, Request, Response } from 'express';
+import { AddressInfo } from 'node:net';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    query: vi.fn(),
+    tracksFiltered: vi.fn(),
+}));
+
+vi.mock('../config/database', () => ({
+    pool: { query: mocks.query },
+}));
+
+vi.mock('../utils/auth', () => ({
+    requireAuth: (req: Request, _res: Response, next: NextFunction) => {
+        req.authUser = { id: 1, spotifyId: 'owner-spotify-id' };
+        next();
+    },
+}));
+
+vi.mock('../utils/http', () => ({
+    rateLimit: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock('../utils/metrics', () => ({
+    metrics: {
+        playlistCreated: { inc: vi.fn() },
+        blendExecuted: { inc: vi.fn() },
+        tracksFiltered: { inc: mocks.tracksFiltered },
+    },
+}));
+
+vi.mock('../utils/logger', () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    },
+}));
+
+import playlistsRouter from '../routes/playlists';
+
+const exporter = new tracing.InMemorySpanExporter();
+let telemetry: NodeSDK;
+
+const playlist = {
+    id: 12,
+    name: 'My ReBlend',
+    description: 'A blended playlist',
+    owner_id: 1,
+    spotify_playlist_id: null,
+    status: 'pending',
+};
+
+const member = {
+    id: 1,
+    spotify_id: 'owner-spotify-id',
+    display_name: 'owner@example.com',
+    access_token: 'owner-access-token',
+    refresh_token: 'owner-refresh-token',
+    token_expires_at: new Date(Date.now() + 60_000),
+};
+
+const track = {
+    id: 'track-1',
+    uri: 'spotify:track:track-1',
+    name: 'Track 1',
+    artists: [{ name: 'Artist' }],
+    album: { name: 'Album', images: [] },
+    duration_ms: 180_000,
+};
+
+beforeAll(() => {
+    vi.stubEnv('OTEL_SDK_DISABLED', 'false');
+    vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
+    telemetry = new NodeSDK({
+        instrumentations: [],
+        spanProcessors: [new tracing.SimpleSpanProcessor(exporter)],
+    });
+    telemetry.start();
+});
+
+afterAll(async () => {
+    await telemetry.shutdown();
+    vi.unstubAllEnvs();
+});
+
+beforeEach(() => {
+    exporter.reset();
+    vi.restoreAllMocks();
+    mocks.query.mockImplementation((query: string) => {
+        if (query.includes('owner_id = $2') || query === 'SELECT * FROM playlists WHERE id = $1') {
+            return Promise.resolve({ rows: [playlist] });
+        }
+        if (query.includes('FROM playlist_members')) {
+            return Promise.resolve({ rows: [member] });
+        }
+        if (query.includes('SELECT spotify_id, access_token')) {
+            return Promise.resolve({ rows: [{ spotify_id: member.spotify_id, access_token: member.access_token }] });
+        }
+        return Promise.resolve({ rows: [] });
+    });
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: { items: [track] } });
+    vi.spyOn(axios, 'post').mockImplementation(async (url: string) => ({
+        data: url.includes('/users/')
+            ? { id: 'new-spotify-playlist', external_urls: { spotify: 'https://open.spotify.com/playlist/new-spotify-playlist' } }
+            : {},
+    }));
+});
+
+afterEach(() => {
+    mocks.query.mockReset();
+});
+
+async function finishedSpans() {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    return exporter.getFinishedSpans();
+}
+
+async function postGenerate(): Promise<globalThis.Response> {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/playlists', playlistsRouter);
+    const server = app.listen(0, '127.0.0.1');
+
+    try {
+        await new Promise<void>(resolve => server.once('listening', resolve));
+        const { port } = server.address() as AddressInfo;
+        return await fetch(`http://127.0.0.1:${port}/api/playlists/12/generate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sortMode: 'shuffle' }),
+        });
+    } finally {
+        await new Promise<void>((resolve, reject) => {
+            server.close(error => error ? reject(error) : resolve());
+        });
+    }
+}
+
+describe('playlist generation tracing', () => {
+    it('records generation children from the POST endpoint without sensitive attributes', async () => {
+        const response = await postGenerate();
+
+        expect(response.status).toBe(200);
+        const spans = await finishedSpans();
+        const generation = spans.find(span => span.name === 'playlist.generate');
+        expect(generation).toBeDefined();
+        expect(generation?.attributes).toMatchObject({
+            'playlist.id': 12,
+            'playlist.member_count': 1,
+            'blend.sort_mode': 'shuffle',
+            'blend.track_count': 1,
+            'playlist.created': true,
+        });
+
+        for (const spanName of ['spotify.top_tracks', 'tracks.filter', 'blend.tracks', 'spotify.playlist.write']) {
+            const child = spans.find(span => span.name === spanName);
+            expect(child).toBeDefined();
+            expect(child?.parentSpanContext?.spanId).toBe(generation?.spanContext().spanId);
+        }
+
+        expect(spans.find(span => span.name === 'spotify.top_tracks')?.attributes).toMatchObject({
+            'spotify.user_id': 1,
+            'spotify.track_count': 1,
+        });
+        expect(spans.find(span => span.name === 'tracks.filter')?.attributes).toMatchObject({
+            'filter.input_count': 1,
+            'filter.filtered_by_name': 0,
+            'filter.filtered_by_duration': 0,
+            'filter.output_count': 1,
+        });
+        expect(spans.find(span => span.name === 'blend.tracks')?.attributes).toMatchObject({
+            'blend.user_count': 1,
+            'blend.sort_mode': 'shuffle',
+            'blend.total_tracks': 100,
+        });
+
+        const serializedAttributes = JSON.stringify(spans.map(span => span.attributes));
+        expect(serializedAttributes).not.toContain('owner-access-token');
+        expect(serializedAttributes).not.toContain('owner-refresh-token');
+        expect(serializedAttributes).not.toContain('owner@example.com');
+        expect(serializedAttributes).not.toContain('owner-spotify-id');
+    });
+
+    it('marks the top-track and generation spans as errors when top tracks fail', async () => {
+        vi.spyOn(axios, 'get').mockRejectedValue(new Error('Spotify unavailable'));
+
+        const response = await postGenerate();
+
+        expect(response.status).toBe(400);
+        const spans = await finishedSpans();
+        for (const spanName of ['spotify.top_tracks', 'playlist.generate']) {
+            const span = spans.find(candidate => candidate.name === spanName);
+            expect(span?.status.code).toBe(2);
+            expect(span?.events.some(event => event.name === 'exception')).toBe(true);
+        }
+    });
+});

--- a/packages/backend/src/services/playlist-generation.ts
+++ b/packages/backend/src/services/playlist-generation.ts
@@ -5,6 +5,7 @@ import { getValidAccessToken } from './spotify-token';
 import { decryptSecret } from '../utils/crypto';
 import { logger } from '../utils/logger';
 import { metrics } from '../utils/metrics';
+import { recordSpanError, withSpan } from '../utils/tracing';
 
 export type SkippedMember = {
     id: number;
@@ -32,160 +33,172 @@ export async function generatePlaylist(
     playlistId: number,
     options: { sortMode: SortMode; requestedBy?: number }
 ): Promise<GenerateOutcome> {
-    const playlistResult = await pool.query(
-        'SELECT * FROM playlists WHERE id = $1',
-        [playlistId]
-    );
-    if (playlistResult.rows.length === 0) {
-        throw new Error(`Playlist ${playlistId} not found`);
-    }
-    const playlist = playlistResult.rows[0];
-
-    const membersResult = await pool.query(
-        `SELECT u.id, u.spotify_id, u.display_name, u.access_token, u.refresh_token, u.token_expires_at, u.token_status
-       FROM playlist_members pm
-       JOIN users u ON pm.user_id = u.id
-       WHERE pm.playlist_id = $1
-       ORDER BY pm.created_at ASC, pm.id ASC`,
-        [playlistId]
-    );
-
-    if (membersResult.rows.length === 0) {
-        return { ok: false, reason: 'no-members', skippedMembers: [] };
-    }
-
-    const userTracks = new Map<string, SpotifyTrack[]>();
-    const skippedMembers: SkippedMember[] = [];
-    let ownerAccessToken: string | null = null;
-
-    for (const member of membersResult.rows) {
-        const { accessToken, tokenInvalid } = await getValidAccessToken(member, {
-            onRefreshError: (error) => {
-                logger.error({ err: error, memberId: member.id }, 'Failed to refresh token');
-            },
-        });
-        if (!accessToken) {
-            skippedMembers.push({
-                id: member.id,
-                displayName: member.display_name,
-                reason: tokenInvalid ? 'token-invalid' : 'no-tracks',
-            });
-            continue;
-        }
-
-        if (member.id === playlist.owner_id) {
-            ownerAccessToken = accessToken;
-        }
-
-        try {
-            let tracks = await spotifyService.getTopTracks(accessToken, 50);
-            const filterResult = spotifyService.filterTracks(tracks);
-            tracks = filterResult.tracks;
-
-            if (filterResult.filteredByDuration > 0) {
-                metrics.tracksFiltered.inc({ reason: 'duration' }, filterResult.filteredByDuration);
-            }
-            if (filterResult.filteredByName > 0) {
-                metrics.tracksFiltered.inc({ reason: 'name' }, filterResult.filteredByName);
-            }
-            logger.info({
-                playlistId,
-                memberId: member.id,
-                filteredByDuration: filterResult.filteredByDuration,
-                filteredByName: filterResult.filteredByName,
-                remaining: tracks.length,
-            }, 'Filtered tracks for blend');
-            if (tracks.length === 0) {
-                skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
-            }
-            userTracks.set(member.spotify_id, tracks);
-        } catch (error) {
-            logger.error({ err: error, memberId: member.id }, 'Failed to get top tracks');
-            skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
-        }
-    }
-
-    if (userTracks.size === 0) {
-        return { ok: false, reason: 'no-tokens', skippedMembers };
-    }
-
-    const { tracks } = await blendTracks(userTracks, { totalTracks: 100, sortMode: options.sortMode });
-
-    if (tracks.length === 0) {
-        return { ok: false, reason: 'no-tracks', skippedMembers };
-    }
-
-    const ownerResult = await pool.query(
-        'SELECT spotify_id, access_token FROM users WHERE id = $1',
-        [playlist.owner_id]
-    );
-    const owner = ownerResult.rows[0];
-
-    if (!ownerAccessToken) {
-        ownerAccessToken = decryptSecret(owner.access_token);
-    }
-
-    if (!ownerAccessToken) {
-        return { ok: false, reason: 'owner-token-unavailable', skippedMembers };
-    }
-
-    const created = !playlist.spotify_playlist_id;
-    let spotifyPlaylistId: string = playlist.spotify_playlist_id;
-    let spotifyUrl = '';
-
-    if (spotifyPlaylistId) {
-        await spotifyService.clearPlaylistTracks(ownerAccessToken, spotifyPlaylistId);
-        await spotifyService.addTracksToPlaylist(ownerAccessToken, spotifyPlaylistId, tracks.map(track => track.uri));
-        spotifyUrl = `https://open.spotify.com/playlist/${spotifyPlaylistId}`;
-    } else {
-        const spotifyPlaylist = await spotifyService.createPlaylist(
-            ownerAccessToken,
-            owner.spotify_id,
-            playlist.name,
-            playlist.description || `ReBlend playlist with ${membersResult.rows.length} members`
+    return withSpan('playlist.generate', {
+        'playlist.id': playlistId,
+        'blend.sort_mode': options.sortMode,
+    }, async span => {
+        const playlistResult = await pool.query(
+            'SELECT * FROM playlists WHERE id = $1',
+            [playlistId]
         );
-        spotifyPlaylistId = spotifyPlaylist.id;
-        spotifyUrl = spotifyPlaylist.external_urls.spotify;
+        if (playlistResult.rows.length === 0) {
+            throw new Error(`Playlist ${playlistId} not found`);
+        }
+        const playlist = playlistResult.rows[0];
+        span?.setAttribute('playlist.created', !playlist.spotify_playlist_id);
 
-        await spotifyService.addTracksToPlaylist(ownerAccessToken, spotifyPlaylistId, tracks.map(track => track.uri));
-        await pool.query(
-            `UPDATE playlists SET spotify_playlist_id = $1, status = 'generated', updated_at = CURRENT_TIMESTAMP
-           WHERE id = $2`,
-            [spotifyPlaylistId, playlistId]
+        const membersResult = await pool.query(
+            `SELECT u.id, u.spotify_id, u.display_name, u.access_token, u.refresh_token, u.token_expires_at, u.token_status
+           FROM playlist_members pm
+           JOIN users u ON pm.user_id = u.id
+           WHERE pm.playlist_id = $1
+           ORDER BY pm.created_at ASC, pm.id ASC`,
+            [playlistId]
         );
+        span?.setAttribute('playlist.member_count', membersResult.rows.length);
+
+        if (membersResult.rows.length === 0) {
+            return { ok: false, reason: 'no-members', skippedMembers: [] };
+        }
+
+        const userTracks = new Map<string, SpotifyTrack[]>();
+        const skippedMembers: SkippedMember[] = [];
+        let ownerAccessToken: string | null = null;
 
         for (const member of membersResult.rows) {
-            if (member.id !== playlist.owner_id) {
-                try {
-                    const { accessToken } = await getValidAccessToken(member, {
-                        onRefreshError: (error) => {
-                            logger.error({ err: error, memberId: member.id }, 'Failed to refresh token');
-                        },
-                    });
-                    if (accessToken) {
-                        await spotifyService.followPlaylist(accessToken, spotifyPlaylistId);
+            const { accessToken, tokenInvalid } = await getValidAccessToken(member, {
+                onRefreshError: (error) => {
+                    recordSpanError(error);
+                    logger.error({ err: error, memberId: member.id }, 'Failed to refresh token');
+                },
+            });
+            if (!accessToken) {
+                skippedMembers.push({
+                    id: member.id,
+                    displayName: member.display_name,
+                    reason: tokenInvalid ? 'token-invalid' : 'no-tracks',
+                });
+                continue;
+            }
+
+            if (member.id === playlist.owner_id) {
+                ownerAccessToken = accessToken;
+            }
+
+            try {
+                let tracks = await spotifyService.getTopTracks(accessToken, 50, member.id);
+                const filterResult = spotifyService.filterTracks(tracks);
+                tracks = filterResult.tracks;
+
+                if (filterResult.filteredByDuration > 0) {
+                    metrics.tracksFiltered.inc({ reason: 'duration' }, filterResult.filteredByDuration);
+                }
+                if (filterResult.filteredByName > 0) {
+                    metrics.tracksFiltered.inc({ reason: 'name' }, filterResult.filteredByName);
+                }
+                logger.info({
+                    playlistId,
+                    memberId: member.id,
+                    filteredByDuration: filterResult.filteredByDuration,
+                    filteredByName: filterResult.filteredByName,
+                    remaining: tracks.length,
+                }, 'Filtered tracks for blend');
+                if (tracks.length === 0) {
+                    skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
+                }
+                userTracks.set(member.spotify_id, tracks);
+            } catch (error) {
+                recordSpanError(error);
+                logger.error({ err: error, memberId: member.id }, 'Failed to get top tracks');
+                skippedMembers.push({ id: member.id, displayName: member.display_name, reason: 'no-tracks' });
+            }
+        }
+
+        if (userTracks.size === 0) {
+            return { ok: false, reason: 'no-tokens', skippedMembers };
+        }
+
+        const { tracks } = await blendTracks(userTracks, { totalTracks: 100, sortMode: options.sortMode });
+        span?.setAttribute('blend.track_count', tracks.length);
+
+        if (tracks.length === 0) {
+            return { ok: false, reason: 'no-tracks', skippedMembers };
+        }
+
+        const ownerResult = await pool.query(
+            'SELECT spotify_id, access_token FROM users WHERE id = $1',
+            [playlist.owner_id]
+        );
+        const owner = ownerResult.rows[0];
+
+        if (!ownerAccessToken) {
+            ownerAccessToken = decryptSecret(owner.access_token);
+        }
+
+        if (!ownerAccessToken) {
+            return { ok: false, reason: 'owner-token-unavailable', skippedMembers };
+        }
+
+        const created = !playlist.spotify_playlist_id;
+        let spotifyPlaylistId: string = playlist.spotify_playlist_id;
+        let spotifyUrl = '';
+
+        if (spotifyPlaylistId) {
+            await spotifyService.clearPlaylistTracks(ownerAccessToken, spotifyPlaylistId);
+            await spotifyService.addTracksToPlaylist(ownerAccessToken, spotifyPlaylistId, tracks.map(track => track.uri));
+            spotifyUrl = `https://open.spotify.com/playlist/${spotifyPlaylistId}`;
+        } else {
+            const spotifyPlaylist = await spotifyService.createPlaylist(
+                ownerAccessToken,
+                owner.spotify_id,
+                playlist.name,
+                playlist.description || `ReBlend playlist with ${membersResult.rows.length} members`
+            );
+            spotifyPlaylistId = spotifyPlaylist.id;
+            spotifyUrl = spotifyPlaylist.external_urls.spotify;
+
+            await spotifyService.addTracksToPlaylist(ownerAccessToken, spotifyPlaylistId, tracks.map(track => track.uri));
+            await pool.query(
+                `UPDATE playlists SET spotify_playlist_id = $1, status = 'generated', updated_at = CURRENT_TIMESTAMP
+               WHERE id = $2`,
+                [spotifyPlaylistId, playlistId]
+            );
+
+            for (const member of membersResult.rows) {
+                if (member.id !== playlist.owner_id) {
+                    try {
+                        const { accessToken } = await getValidAccessToken(member, {
+                            onRefreshError: (error) => {
+                                recordSpanError(error);
+                                logger.error({ err: error, memberId: member.id }, 'Failed to refresh token');
+                            },
+                        });
+                        if (accessToken) {
+                            await spotifyService.followPlaylist(accessToken, spotifyPlaylistId);
+                        }
+                    } catch (error) {
+                        recordSpanError(error);
+                        logger.error({ err: error, memberId: member.id }, 'Failed to follow playlist');
                     }
-                } catch (error) {
-                    logger.error({ err: error, memberId: member.id }, 'Failed to follow playlist');
                 }
             }
         }
-    }
 
-    if (playlist.status !== 'generated') {
-        await pool.query(
-            `UPDATE playlists SET status = 'generated', updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
-            [playlistId]
-        );
-    }
+        if (playlist.status !== 'generated') {
+            await pool.query(
+                `UPDATE playlists SET status = 'generated', updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+                [playlistId]
+            );
+        }
 
-    return {
-        ok: true,
-        spotifyPlaylistId,
-        spotifyUrl,
-        trackCount: tracks.length,
-        created,
-        memberCount: membersResult.rows.length,
-        skippedMembers,
-    };
+        return {
+            ok: true,
+            spotifyPlaylistId,
+            spotifyUrl,
+            trackCount: tracks.length,
+            created,
+            memberCount: membersResult.rows.length,
+            skippedMembers,
+        };
+    });
 }

--- a/packages/backend/src/services/reccobeats.ts
+++ b/packages/backend/src/services/reccobeats.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { logger } from '../utils/logger';
+import { recordSpanError, withSpan } from '../utils/tracing';
 
 const RECCOBEATS_API_BASE = 'https://api.reccobeats.com/v1';
 
@@ -58,6 +59,7 @@ class ReccoBeatsService {
             }
             return null;
         } catch (error) {
+            recordSpanError(error);
             logger.debug({ isrc, err: error }, 'Failed to get ReccoBeats track');
             return null;
         }
@@ -71,6 +73,7 @@ class ReccoBeatsService {
             const response = await this.client.get<AudioFeatures>(`/track/${reccobeatsId}/audio-features`);
             return response.data;
         } catch (error) {
+            recordSpanError(error);
             logger.debug({ reccobeatsId, err: error }, 'Failed to get audio features');
             return null;
         }
@@ -83,45 +86,49 @@ class ReccoBeatsService {
     async getAudioFeaturesForTracks(
         tracks: Array<{ spotifyId: string; isrc: string | undefined }>
     ): Promise<Map<string, AudioFeatures>> {
-        const featuresMap = new Map<string, AudioFeatures>();
-        
-        // Process in batches to avoid rate limiting
-        const batchSize = 10;
-        const delayMs = 100;
-
-        for (let i = 0; i < tracks.length; i += batchSize) {
-            const batch = tracks.slice(i, i + batchSize);
+        return withSpan('reccobeats.audio_features', { 'reccobeats.requested': tracks.length }, async span => {
+            const featuresMap = new Map<string, AudioFeatures>();
             
-            const promises = batch.map(async (track) => {
-                if (!track.isrc) return null;
+            // Process in batches to avoid rate limiting
+            const batchSize = 10;
+            const delayMs = 100;
 
-                try {
-                    // First get the ReccoBeats track ID
-                    const reccoTrack = await this.getTrackByIsrc(track.isrc);
-                    if (!reccoTrack) return null;
+            for (let i = 0; i < tracks.length; i += batchSize) {
+                const batch = tracks.slice(i, i + batchSize);
 
-                    // Then get audio features
-                    const features = await this.getAudioFeatures(reccoTrack.id);
-                    if (features) {
-                        featuresMap.set(track.spotifyId, features);
+                const promises = batch.map(async (track) => {
+                    if (!track.isrc) return null;
+
+                    try {
+                        // First get the ReccoBeats track ID
+                        const reccoTrack = await this.getTrackByIsrc(track.isrc);
+                        if (!reccoTrack) return null;
+
+                        // Then get audio features
+                        const features = await this.getAudioFeatures(reccoTrack.id);
+                        if (features) {
+                            featuresMap.set(track.spotifyId, features);
+                        }
+                        return features;
+                    } catch (error) {
+                        recordSpanError(error);
+                        logger.debug({ spotifyId: track.spotifyId, isrc: track.isrc }, 'Failed to get features for track');
+                        return null;
                     }
-                    return features;
-                } catch (error) {
-                    logger.debug({ spotifyId: track.spotifyId, isrc: track.isrc }, 'Failed to get features for track');
-                    return null;
+                });
+
+                await Promise.all(promises);
+
+                // Add delay between batches to avoid rate limiting
+                if (i + batchSize < tracks.length) {
+                    await new Promise(resolve => setTimeout(resolve, delayMs));
                 }
-            });
-
-            await Promise.all(promises);
-
-            // Add delay between batches to avoid rate limiting
-            if (i + batchSize < tracks.length) {
-                await new Promise(resolve => setTimeout(resolve, delayMs));
             }
-        }
 
-        logger.info({ totalTracks: tracks.length, featuresFound: featuresMap.size }, 'Fetched audio features');
-        return featuresMap;
+            span?.setAttribute('reccobeats.resolved', featuresMap.size);
+            logger.info({ totalTracks: tracks.length, featuresFound: featuresMap.size }, 'Fetched audio features');
+            return featuresMap;
+        });
     }
 }
 

--- a/packages/backend/src/services/spotify.ts
+++ b/packages/backend/src/services/spotify.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { logger } from '../utils/logger';
+import { withSpan } from '../utils/tracing';
 
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 const SPOTIFY_AUTH_BASE = 'https://accounts.spotify.com';
@@ -186,15 +187,20 @@ export class SpotifyService {
         return response.data;
     }
 
-    async getTopTracks(accessToken: string, limit: number = 50): Promise<SpotifyTrack[]> {
-        const response = await retryOnRateLimit(() => axios.get(`${SPOTIFY_API_BASE}/me/top/tracks`, {
-            headers: { Authorization: `Bearer ${accessToken}` },
-            params: {
-                time_range: 'short_term', // Last 4 weeks (1 month)
-                limit,
-            },
-        }));
-        return response.data.items;
+    async getTopTracks(accessToken: string, limit: number = 50, userId?: number): Promise<SpotifyTrack[]> {
+        return withSpan('spotify.top_tracks', {
+            ...(userId === undefined ? {} : { 'spotify.user_id': userId }),
+        }, async span => {
+            const response = await retryOnRateLimit(() => axios.get(`${SPOTIFY_API_BASE}/me/top/tracks`, {
+                headers: { Authorization: `Bearer ${accessToken}` },
+                params: {
+                    time_range: 'short_term', // Last 4 weeks (1 month)
+                    limit,
+                },
+            }));
+            span?.setAttribute('spotify.track_count', response.data.items.length);
+            return response.data.items;
+        });
     }
 
     /**
@@ -224,15 +230,24 @@ export class SpotifyService {
     }
 
     filterTracks(tracks: SpotifyTrack[], options: TrackFilterOptions = {}): TrackFilterResult {
-        const minDurationMs = options.minDurationMs ?? this.getMinTrackDurationMs();
-        const tracksWithoutInstrumentals = this.filterInstrumentalTracks(tracks);
-        const filteredTracks = this.filterShortTracks(tracksWithoutInstrumentals, minDurationMs);
+        return withSpan('tracks.filter', { 'filter.input_count': tracks.length }, span => {
+            const minDurationMs = options.minDurationMs ?? this.getMinTrackDurationMs();
+            const tracksWithoutInstrumentals = this.filterInstrumentalTracks(tracks);
+            const filteredTracks = this.filterShortTracks(tracksWithoutInstrumentals, minDurationMs);
+            const filteredByName = tracks.length - tracksWithoutInstrumentals.length;
+            const filteredByDuration = tracksWithoutInstrumentals.length - filteredTracks.length;
 
-        return {
-            tracks: filteredTracks,
-            filteredByName: tracks.length - tracksWithoutInstrumentals.length,
-            filteredByDuration: tracksWithoutInstrumentals.length - filteredTracks.length,
-        };
+            span?.setAttributes({
+                'filter.filtered_by_name': filteredByName,
+                'filter.filtered_by_duration': filteredByDuration,
+                'filter.output_count': filteredTracks.length,
+            });
+            return {
+                tracks: filteredTracks,
+                filteredByName,
+                filteredByDuration,
+            };
+        });
     }
 
     private getMinTrackDurationMs(): number {
@@ -279,46 +294,57 @@ export class SpotifyService {
         playlistId: string,
         trackUris: string[]
     ): Promise<void> {
-        // Spotify allows max 100 tracks per request
-        for (let i = 0; i < trackUris.length; i += 100) {
-            const batch = trackUris.slice(i, i + 100);
-            await retryOnRateLimit(() => axios.post(
-                `${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`,
-                { uris: batch },
-                {
-                    headers: {
-                        Authorization: `Bearer ${accessToken}`,
-                        'Content-Type': 'application/json',
-                    },
-                }
-            ));
-        }
+        return withSpan('spotify.playlist.write', {
+            'spotify.playlist_id': playlistId,
+            'spotify.batch_count': Math.ceil(trackUris.length / 100),
+        }, async () => {
+            // Spotify allows max 100 tracks per request
+            for (let i = 0; i < trackUris.length; i += 100) {
+                const batch = trackUris.slice(i, i + 100);
+                await retryOnRateLimit(() => axios.post(
+                    `${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`,
+                    { uris: batch },
+                    {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                    }
+                ));
+            }
+        });
     }
 
     async clearPlaylistTracks(accessToken: string, playlistId: string): Promise<void> {
-        // Get current tracks
-        const response = await retryOnRateLimit(() => axios.get(`${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`, {
-            headers: { Authorization: `Bearer ${accessToken}` },
-            params: { fields: 'items(track(uri))' },
-        }));
+        return withSpan('spotify.playlist.write', {
+            'spotify.playlist_id': playlistId,
+            'spotify.batch_count': 0,
+        }, async span => {
+            // Get current tracks
+            const response = await retryOnRateLimit(() => axios.get(`${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`, {
+                headers: { Authorization: `Bearer ${accessToken}` },
+                params: { fields: 'items(track(uri))' },
+            }));
 
-        const trackUris = response.data.items
-            .filter((item: { track: { uri: string } | null }) => item.track)
-            .map((item: { track: { uri: string } }) => ({ uri: item.track.uri }));
+            const trackUris = response.data.items
+                .filter((item: { track: { uri: string } | null }) => item.track)
+                .map((item: { track: { uri: string } }) => ({ uri: item.track.uri }));
+            span?.setAttribute('spotify.batch_count', Math.ceil(trackUris.length / 100));
 
-        if (trackUris.length > 0) {
-            // Remove in batches of 100
-            for (let i = 0; i < trackUris.length; i += 100) {
-                const batch = trackUris.slice(i, i + 100);
-                await retryOnRateLimit(() => axios.delete(`${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`, {
-                    headers: {
-                        Authorization: `Bearer ${accessToken}`,
-                        'Content-Type': 'application/json',
-                    },
-                    data: { tracks: batch },
-                }));
+            if (trackUris.length > 0) {
+                // Remove in batches of 100
+                for (let i = 0; i < trackUris.length; i += 100) {
+                    const batch = trackUris.slice(i, i + 100);
+                    await retryOnRateLimit(() => axios.delete(`${SPOTIFY_API_BASE}/playlists/${playlistId}/tracks`, {
+                        headers: {
+                            Authorization: `Bearer ${accessToken}`,
+                            'Content-Type': 'application/json',
+                        },
+                        data: { tracks: batch },
+                    }));
+                }
             }
-        }
+        });
     }
 
     async getPlaylistTracks(accessToken: string, playlistId: string): Promise<SpotifyTrack[]> {

--- a/packages/backend/src/utils/tracing.test.ts
+++ b/packages/backend/src/utils/tracing.test.ts
@@ -1,0 +1,21 @@
+import { trace } from '@opentelemetry/api';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { withSpan } from './tracing';
+
+afterEach(() => {
+    trace.disable();
+    vi.unstubAllEnvs();
+});
+
+describe('withSpan', () => {
+    it('runs work directly without a configured OpenTelemetry provider', () => {
+        vi.stubEnv('OTEL_SDK_DISABLED', 'true');
+        trace.disable();
+        const work = () => 'completed';
+
+        expect(withSpan('disabled.span', { 'safe.count': 1 }, span => {
+            expect(span).toBeUndefined();
+            return work();
+        })).toBe('completed');
+    });
+});

--- a/packages/backend/src/utils/tracing.ts
+++ b/packages/backend/src/utils/tracing.ts
@@ -1,0 +1,68 @@
+import { context, Span, SpanStatusCode, trace, type Attributes } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('spotify-reblend-backend');
+
+function isTracingEnabled(): boolean {
+    return process.env.OTEL_SDK_DISABLED?.toLowerCase() !== 'true'
+        && Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT);
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is T & PromiseLike<Awaited<T>> {
+    return typeof (value as PromiseLike<T>)?.then === 'function';
+}
+
+function asException(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+export function recordSpanError(error: unknown, span: Span | undefined = trace.getActiveSpan()): void {
+    if (!span?.isRecording()) {
+        return;
+    }
+
+    span.recordException(asException(error));
+    span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+/**
+ * Runs work in a recording span when an OpenTelemetry provider is configured.
+ * With the default no-op provider, work runs directly without creating context.
+ */
+export function withSpan<T>(
+    name: string,
+    attributes: Attributes,
+    fn: (span: Span | undefined) => T
+): T {
+    if (!isTracingEnabled()) {
+        return fn(undefined);
+    }
+
+    const span = tracer.startSpan(name, { attributes });
+    if (!span.isRecording()) {
+        span.end();
+        return fn(undefined);
+    }
+
+    try {
+        const result = context.with(trace.setSpan(context.active(), span), () => fn(span));
+        if (isPromiseLike(result)) {
+            return result.then(
+                value => {
+                    span.end();
+                    return value;
+                },
+                error => {
+                    recordSpanError(error, span);
+                    span.end();
+                    throw error;
+                },
+            ) as T;
+        }
+        span.end();
+        return result;
+    } catch (error) {
+        recordSpanError(error, span);
+        span.end();
+        throw error;
+    }
+}


### PR DESCRIPTION
Closes #207

自動計装（#205）だけでは HTTP と外向き呼び出ししか見えないため、プレイリスト生成の内訳をトレースで追えるようにする。

## 変更

- `utils/tracing.ts` に `withSpan` / `recordSpanError` を追加。OTEL 無効時はスパンを作らず素通りする
- スパン: `playlist.generate` / `spotify.top_tracks` / `tracks.filter` / `blend.tracks` / `reccobeats.audio_features` / `spotify.playlist.write` / `auto_update.run` / `auto_update.playlist`
- 握りつぶしている例外（メンバーのトップ曲取得失敗、follow 失敗など）でも `recordException` + ERROR ステータスを残す。**握りつぶす挙動自体は変えていない**
- 既存の `reblend_*` メトリクスとログはそのまま（トレースは内訳調査用、メトリクスは常時監視用）

## 属性の扱い

トークン・メールアドレス・Spotify アカウント ID は属性に入れない。`spotify.user_id` に入るのは**内部 DB の user id**（Issue #207 の表の定義どおり）。センシティブな属性が付かないことはテストで確認している。

## 差分について

`playlist-generation.ts` の diff が大きく見えるのは `withSpan` のコールバックで囲んだインデント差によるもの。`git diff -w` で見ると実質の変更は15行の計装追加のみで、生成ロジックは変えていない。

backend 88 tests passed。`InMemorySpanExporter` でスパン名と親子関係、エラー時のステータスを観測している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)